### PR TITLE
Move GA script stuff to site-footer

### DIFF
--- a/blog-src/themes/ananke/layouts/index.html
+++ b/blog-src/themes/ananke/layouts/index.html
@@ -53,7 +53,6 @@
         {{ end }}
         </section>
       {{ end }}
-      {{ template "_internal/google_analytics.html" . }}
       </div>
   {{ end }}
 {{ end }}

--- a/blog-src/themes/ananke/layouts/partials/site-footer.html
+++ b/blog-src/themes/ananke/layouts/partials/site-footer.html
@@ -8,3 +8,15 @@
   </div>
   </div>
 </footer>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-86980724-1', 'auto');
+  ga('send', 'pageview');
+</script>
+
+<script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0059/9755.js" async="async"></script>

--- a/blog-src/themes/ananke/layouts/post/single.html
+++ b/blog-src/themes/ananke/layouts/post/single.html
@@ -25,16 +25,6 @@
     <div class="ph3 mt2 mt6-ns">
       {{ partial "menu-contextual.html" . }}
     </div>
-     {{ with .Site.Params.googleAnalytics }}
-     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', 'UA-86980724-1', 'auto');
-      ga('send', 'pageview');
-    </script>
-    <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0059/9755.js" async="async"></script>
   </div>
 {{ end }}


### PR DESCRIPTION
Remove calls to hugo's built in GA and use our own.  Move it to the site footer partial, since that one is used everywhere.

cc @timirahj 