### PR TITLE
Fixed broken links in documentation

### DIFF
--- a/content/en/blog/fission-hello-world.md
+++ b/content/en/blog/fission-hello-world.md
@@ -25,7 +25,7 @@ We'll be using Minikube to run Kubernetes locally (just as we did in the [previo
 
 ### Install Minikube
 
- Go ahead and follow the instructions to install Minikube [here](https://github.com/kubernetes/minikube).
+ Go ahead and follow the instructions to [install Minikube](https://github.com/kubernetes/minikube).
 
 After you have Minikube installed, launch your cluster by running the following command:			
 					
@@ -124,7 +124,7 @@ Finally, we can invoke our function, using this command:
 
 ## What's Next?
 
-Go ahead and try your hand at using Fission Functions for your own cool projects! Remember that you can use Fission with other languages. Try it out using NodeJS, Python, Ruby, or any of the other languages within our listed [environments](https://github.com/fission/fission/tree/master/environments)! Don't forget to tell us about what you made by tweeting us [@fissionio](http://twitter.com/fissionio), and feel free to ask questions on our Slack http://fissionio.slack.com.
+Go ahead and try your hand at using Fission Functions for your own cool projects! Remember that you can use Fission with other languages. Try it out using NodeJS, Python, Ruby, or any of the other languages within our listed [fission environments](https://environments.fission.io/)! Don't forget to tell us about what you made by tweeting us [@fissionio](http://twitter.com/fissionio), and feel free to ask questions on our Slack http://fissionio.slack.com.
 
 
 

--- a/content/en/blog/fission_github_action.md
+++ b/content/en/blog/fission_github_action.md
@@ -53,7 +53,7 @@ First, a quick overview of what goes on behind the scenes of the Fission GitHub 
 
 ## Building a workflow with the Fission GitHub Action
 
-Now using this Action - let’s build a simple workflow which will be triggered once there’s a code push and deploy/apply the functions. The workflow is defined in .github/main.workflow file in the same repository as code. You can check out more details and [options of GitHub workflow here](https://developer.github.com/actions/managing-workflows/workflow-configuration-options/)
+Now using this Action - let’s build a simple workflow which will be triggered once there’s a code push and deploy/apply the functions. The workflow is defined in .github/main.workflow file in the same repository as code. You can check out more details and [options of GitHub workflow here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions)
 
 
 ```

--- a/content/en/blog/how-to-develop-a-serverless-application-with-fission-pt-1.md
+++ b/content/en/blog/how-to-develop-a-serverless-application-with-fission-pt-1.md
@@ -252,7 +252,7 @@ dependencies in real world. To support this, here are couple steps to follow wit
 2. Archive all go files (include dependencies)
 3. Create function with ZIP file just created
 
-Let's use [vendor-example](https://github.com/fission/examples/tree/master/go/module-example) as demonstration. The structure of `vendor-example` looks like this
+Let's use [vendor-example](https://github.com/fission/fission/tree/master/examples/go/vendor-example) as demonstration. The structure of `vendor-example` looks like this
 ```bash
 vendor-example/
 ├── main.go

--- a/content/en/blog/how-to-develop-a-serverless-application-with-fission-pt-1.md
+++ b/content/en/blog/how-to-develop-a-serverless-application-with-fission-pt-1.md
@@ -252,7 +252,7 @@ dependencies in real world. To support this, here are couple steps to follow wit
 2. Archive all go files (include dependencies)
 3. Create function with ZIP file just created
 
-Let's use [vendor-example](https://github.com/fission/fission/tree/master/examples/go/vendor-example) as demonstration. The structure of `vendor-example` looks like this
+Let's use [vendor-example](https://github.com/fission/examples/tree/master/go/module-example) as demonstration. The structure of `vendor-example` looks like this
 ```bash
 vendor-example/
 ├── main.go

--- a/content/en/blog/women-in-open-source-highlight.md
+++ b/content/en/blog/women-in-open-source-highlight.md
@@ -85,7 +85,7 @@ Everyone supports each other, especially to the new-comers.
 
 **Twitter:** [@mary_grace](https://twitter.com/mary_grace)
 
-**Github:*** [github.com/mary-grace](https://github.coom/mary-grace)
+**Github:*** [github.com/mary-grace](https://github.com/mary-grace)
 
 
 _**What encouraged you to get into Open Source?**_

--- a/content/en/docs/usage/languages/go.md
+++ b/content/en/docs/usage/languages/go.md
@@ -376,7 +376,7 @@ $ fission fn test --name foobar
 
 ### Custom builds
 
-If no custom build script included in source archive, by default builder manager will execute the [build.sh](https://github.com/fission/fission/tree/master/environments/go/builder) in go builder image.
+If no custom build script included in source archive, by default builder manager will execute the [build.sh](https://github.com/fission/environments/blob/master/go/builder/build.sh) in go builder image.
 In this part, we will go through how to run custom build script during the build process.
 
 Before we write our own script, we need to dive into the original build script to see what's useful inside.
@@ -495,7 +495,7 @@ Build timestamp: 1540566887
 
 ### Modifying/Rebuild the environment images
 
-For how to rebuild environment image, please visit [here](https://github.com/fission/environments/blob/master/go/README.md)
+Refer to our [Go environment guide for Fission](https://github.com/fission/environments/blob/master/go/README.md) to learn about rebuilding environment images.
 
 ### Resource usage
 

--- a/content/en/docs/usage/languages/java.md
+++ b/content/en/docs/usage/languages/java.md
@@ -273,10 +273,9 @@ Package 'java-src-pkg-zip-dqo5' created
 
 ### Modifying the environment images
 
-The JVM environment's source code is available [here](https://github.com/fission/fission/tree/master/environments/jvm).
-If you only want to add libraries to the OS or add some additional files etc. to environment, it would be easier to simply extend the official Fission JVM environment image and use it.
+If you only want to add libraries to the OS or add some additional files etc. to environment, it would be easier to simply extend the official [Fission JVM environment](https://github.com/fission/environments/tree/master/jvm) image and use it.
 
-The JVM builder image source code is [available here](https://github.com/fission/fission/tree/master/environments/jvm/builder) and could be extended or written from scratch to use other tools such as Gradle etc.
+The JVM builder image source code is [available here](https://github.com/fission/environments/tree/master/jvm) and could be extended or written from scratch to use other tools such as Gradle etc.
 It would be easier to extend the Fission official image and then add tools.
 
 ### Resource usage
@@ -342,5 +341,5 @@ fission spec apply
 
 ### Samples
 
-- The Fission Kafka sample is a complete application written in Java and uses Kafka to interact between functions. The source code and more information can be found [here](https://github.com/fission/fission-kafka-sample)
-- The Fission workflow sample uses [Fission workflows](https://github.com/fission/fission-workflows) and Java functions. The source code and more information can be found [here](https://github.com/fission/fission-workflow-sample)
+- The Fission Kafka sample is a complete application written in Java and uses Kafka to interact between functions. Refer to our [Fission Kakfa sample](https://github.com/fission/fission-kafka-sample) to know more.
+- The Fission workflow sample uses [Fission workflows](https://github.com/fission/fission-workflows) and Java functions. You can refer to the [fission workflow sample](https://github.com/fission/fission-workflow-sample) code to get started.

--- a/content/en/docs/usage/languages/nodejs.md
+++ b/content/en/docs/usage/languages/nodejs.md
@@ -59,7 +59,7 @@ fission fn test --name hello-world
 #### Accessing HTTP Requests
 
 This section gives a few examples of invoking nodejs functions with HTTP requests and how HTTP request components can be extracted inside the function.
-While these examples give you a rough idea of the usage, there are more real world examples [here](https://github.com/fission/examples/tree/master/nodejs)
+While these examples give you a rough idea of the usage, here are some more [real world examples](https://github.com/fission/examples/tree/master/nodejs) that you can refer to.
 
 ##### Headers
 
@@ -413,7 +413,7 @@ Next, the user function is loaded according to the entry point specified with `f
 #### Creating a custom nodejs builder image
 
 If you'd like to do more than just `npm install` in the build step, you could customize the `build.sh`.
-Here's the link to the source code of fission [nodejs builder](https://github.com/fission/fission/tree/master/environments/nodejs/builder)
+Here's the link to the source code of [fission nodejs builder](https://github.com/fission/environments/tree/master/nodejs/builder)
 
 As you can see, the build.sh performs a `npm install` inside a directory defined by the environment variable SRC_PKG and copies the built archive into a directory defined by environment variable DEPLOY_PKG.
 You could create a customized version of this build.sh with whatever additional commands needed to be run during the build step.
@@ -426,7 +426,7 @@ Now you are ready to create a nodejs env with your custom builder image supplied
 
 If you wish to modify the nodejs runtime image to add more dependencies without using/creating a builder image, you can do so too.
 
-Here's the link to the source code of fission [nodejs runtime](https://github.com/fission/fission/tree/master/environments/nodejs)
+Here's the link to the source code of [fission nodejs runtime](https://github.com/fission/environments/tree/master/nodejs/)
 
 As you can see, there is a package.json in the directory with a list of node modules listed under dependencies section.
 You can add the node modules required to this list and then build the docker image with `docker build -t <USER>/nodejs-custom-runtime .` and push the image `docker push <USER>/nodejs-custom-runtime`.

--- a/content/en/docs/usage/observability/prometheus.md
+++ b/content/en/docs/usage/observability/prometheus.md
@@ -143,11 +143,10 @@ There are other more Fission metrics, which can be found under `Metrics` in the 
 
 With Grafana, visuals dashboards can be created to monitor multiple metrics in an organized way.
 
-One such dashboard can be found [here](https://github.com/fission/examples/blob/master/dashboards/prometheus-fission-functions.json).
-This dashboard shows log metrics from all the major components of Fission.
+You can refer to [this dashboard](https://github.com/fission/examples/blob/master/dashboards/prometheus-fission-functions.json) that shows log metrics from all the major components of Fission.
 
 Once imported, the dashboard will look similar to below image.
 
 ![Prometheus Fission Functions dashboard](../assets/prometheus-grafana.png)
 
-There will be more dashboards added to the same [location](https://github.com/fission/examples/blob/master/dashboards) over time.
+View the list of all [Fission dashboards](https://github.com/fission/examples/blob/master/dashboards) posted over time.

--- a/content/en/docs/usage/observability/prometheus.md
+++ b/content/en/docs/usage/observability/prometheus.md
@@ -143,7 +143,7 @@ There are other more Fission metrics, which can be found under `Metrics` in the 
 
 With Grafana, visuals dashboards can be created to monitor multiple metrics in an organized way.
 
-You can refer to [this dashboard](https://github.com/fission/examples/blob/master/dashboards/prometheus-fission-functions.json) that shows log metrics from all the major components of Fission.
+You can refer to [Fission functions dashboard](https://github.com/fission/examples/blob/master/dashboards/prometheus-fission-functions.json) that shows log metrics from all the major components of Fission.
 
 Once imported, the dashboard will look similar to below image.
 

--- a/content/en/docs/usage/triggers/message-queue-trigger/kafka.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger/kafka.md
@@ -10,11 +10,11 @@ We'll assume you have Fission and Kubernetes installed with Kafka MQ integration
 If not, please head over to the [install guide]({{% ref "../../../installation/_index.en.md" %}}).
 
 You will also need Kafka setup which is reachable from the Fission Kubernetes cluster.
-If you want to setup Kafka on the Kubernetes cluster, you can use the [information here](https://github.com/fission/fission-kafka-sample/tree/master/00_setup).
+If you want to setup Kafka on the Kubernetes cluster, you can refer to this [Fission Kafka Example](https://github.com/fission/fission-kafka-sample#setup).
 
 ## Installation
 
-You can install Kafka through the incubator helm chart [here](https://github.com/helm/charts/tree/master/incubator/kafka).
+You can [install Kafka](https://github.com/helm/charts/tree/master/incubator/kafka) through the incubator helm chart .
 
 ## Overview
 
@@ -29,7 +29,7 @@ Before we dive into details, let's walk through overall flow of event and functi
 {{% notice info %}}
 Fission supports Kafka [record headers](https://issues.apache.org/jira/browse/KAFKA-4208).
 Make sure you set correct version of Kafka to `kafka.version` in values.yaml while installing Fission.
-For more details please refer to Extra configuration section [here](https://github.com/fission/fission/tree/master/charts/#extra-configuration-for-fission-all).
+For more details please refer to [Extra configuration](https://github.com/fission/fission/tree/master/charts/#extra-configuration-for-fission-all) section.
 {{% /notice %}}
 
 ## Building the app
@@ -150,7 +150,7 @@ $ fission mqt create --name kafkatest --function consumerfunc --mqtype kafka --t
 
 If your Kafka broker is running somewhere else (not at `broker.kafka:9092`), you will have to provide custom configuration for Kafka broker host while installing fission.
 You can do that by creating a config file, set the value of `kafka.brokers` to your broker URL and provide this config file while installing fission through helm using -f flag.
-You can refer this [link](https://github.com/fission/fission/blob/master/charts/fission-all/values.yaml) to find out more about this config parameter.
+Suggested reading about [config parameter](https://github.com/fission/fission/blob/master/charts/fission-all/values.yaml) 
 
 ### Testing it out
 

--- a/content/en/docs/usage/triggers/message-queue-trigger/kafka.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger/kafka.md
@@ -150,7 +150,7 @@ $ fission mqt create --name kafkatest --function consumerfunc --mqtype kafka --t
 
 If your Kafka broker is running somewhere else (not at `broker.kafka:9092`), you will have to provide custom configuration for Kafka broker host while installing fission.
 You can do that by creating a config file, set the value of `kafka.brokers` to your broker URL and provide this config file while installing fission through helm using -f flag.
-Suggested reading about [config parameter](https://github.com/fission/fission/blob/master/charts/fission-all/values.yaml) 
+Suggested reading about [helm chart config parameters](https://github.com/fission/fission/blob/master/charts/fission-all/values.yaml) 
 
 ### Testing it out
 


### PR DESCRIPTION
Fixed the following pages that had broken links along with changing the anchor keyword at a few places.

- https://fission.io/docs/usage/triggers/message-queue-trigger/kafka/
- https://fission.io/docs/usage/languages/go/
- https://fission.io/docs/usage/languages/java/
- https://fission.io/docs/usage/languages/java/
- https://fission.io/docs/usage/languages/nodejs/
- https://fission.io/docs/usage/languages/nodejs/
- https://fission.io/blog/new-fission-github-action-easily-automate-your-ci/cd-workflows/
- https://fission.io/blog/how-to-develop-a-serverless-application-with-fission-part-1/
- https://fission.io/blog/women-in-open-source-highlight-series/
- https://fission.io/blog/hello-world-creating-functions-using-fission-in-golang/