### PR TITLE
Fixed Link/Document changes

### DIFF
--- a/content/en/docs/architecture/builder-pod.md
+++ b/content/en/docs/architecture/builder-pod.md
@@ -5,12 +5,19 @@ description: >
   Place to build the user function
 ---
 
-## Brief Intro
-
 Builder Pod is to build source archive into a deployment archive that is able to use in the function pod.
-It contains two containers: Fetcher and Builder Container.
+It contains two containers:
+* Fetcher
+* Builder Container
 
-## Diagram
+### Fetcher
+
+Fetcher is responsible to pull source archive from the [StorageSvc](/docs/architecture/storagesvc/) and verify the checksum of file to ensure the integrity of file.
+After the build process, it uploads the deployment archive to StorageSvc.
+
+### Builder Container
+
+Builder Container compiles function source code into executable binary/files and is language-specific.
 
 {{< img "../assets/builder-pod.png" "Fig.1 Builder Pod" "50em" "1" >}}
 
@@ -23,11 +30,4 @@ Finally, save the result back to the share volume.
 
 6. Builder Manager asks Fetcher to upload the deployment archive.
 
-## Builder Container
 
-Builder Container compiles function source code into executable binary/files and is language-specific.
-
-## Fetcher
-
-Fetcher is responsible to pull source archive from the StorageSvc and verify the checksum of file to ensure the integrity of file.
-After the build process, it uploads the deployment archive to StorageSvc.

--- a/content/en/docs/architecture/builder-pod.md
+++ b/content/en/docs/architecture/builder-pod.md
@@ -5,8 +5,8 @@ description: >
   Place to build the user function
 ---
 
-Builder Pod is to build source archive into a deployment archive that is able to use in the function pod.
-It contains two containers:
+Builder pod builds the source archive and generates a deployment archive. This deployment archive is used by the [function pod](/docs/architecture/function-pod).
+It consists of two containers:
 * Fetcher
 * Builder Container
 

--- a/content/en/docs/architecture/buildermgr.md
+++ b/content/en/docs/architecture/buildermgr.md
@@ -5,15 +5,11 @@ description: >
   Compile the source code into a runnable function
 ---
 
-## Brief Intro
-
 The builder manager watches the package & environments CRD changes and manages the builds of function source code.
 Once an environment that contains a builder  image is created, the builder manager will then create the Kubernetes service and deployment under the fission-builder namespace to start the environment builder.
 And once a package that contains a source archive is created, the builder manager talks to the environment builder to build the function's source archive into a deploy archive for function deployment.
 
 After the build, the builder manager asks Builder to upload the deploy archive to the Storage Service once the build succeeded, and updates the package status attached with build logs.
-
-## Diagram
 
 {{< img "../assets/buildermanager.png" "Fig.1 Builder Manager" "30em" "1" >}}
 

--- a/content/en/docs/architecture/controller.md
+++ b/content/en/docs/architecture/controller.md
@@ -4,17 +4,12 @@ weight: 2
 description: >
   Accept REST API requests and create Fission resources
 ---
-
-## Brief Intro
-
 Controller is the component that the client talks to.
 It contains CRUD APIs for functions, triggers, environments, Kubernetes event watches, etc. and proxy APIs to internal 3rd-party services.
 
-All fission resources are stored in Kubernetes CRDs.
+All fission resources are stored in <a href="https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/" target="_blank">Kubernetes CRDs</a>.
 It needs to be able to talk to Kubernetes API service.
 To access CRDs in all namespaces, a service account with cluster-wide admin permission is used by Controller.
-
-## Diagram
 
 {{< img "../assets/controller.png" "Fig.1 Controller" "40em" "1" >}}
 

--- a/content/en/docs/architecture/executor.md
+++ b/content/en/docs/architecture/executor.md
@@ -5,10 +5,8 @@ description: >
   Component to spin up function pods
 ---
 
-## Brief Intro
-
 Executor is the component to spin up function pods for functions.
-When Router receives requests to a function, it checks whether a function service record exists in its cache.
+When [Router](/docs/architecture/router) receives requests to a function, it checks whether a function service record exists in its cache.
 If cache misses, the function service record was found or expired, it asks Executor to provide a new one.
 Executor then retrieves function information from Kubernetes CRD and invokes one of the executor types to spin up function pods.
 Once the function pods are up, a function service record that contains the address of a service/pod will be returned.
@@ -16,13 +14,11 @@ Router side caching of function service is not applicable in case of poolmanager
 
 Fission now supports two different executor types:
 
-* PoolManager
-* NewDeploy
+* [PoolManager](#poolmanager)
+* [New Deployment](#new-deployment)
 
 These two executor types have different strategies to launch, specialize, and manage pod(s).
 You should choose one of the executor types wisely based on the scenario.
-
-## Diagram
 
 {{< img "../assets/executor.png" "Fig.1 Executor" "40em" "1" >}}
 
@@ -57,8 +53,6 @@ To overcome this limitation, the `concurrency` field is introduced to control th
 
 [1] The cold start time depends on the package size of the function.
 If it's a snippet of code, the cold start time usually is less than 100ms.
-
-#### Diagram
 
 {{< img "../assets/poolmanager.png" "Fig.2 PoolManager" "50em" "1" >}}
 
@@ -96,8 +90,6 @@ When the function is invoked, there is no delay since the pod is already created
 Also minscale ensures that the pods are not cleaned up even if the function is idle.
 This is great for functions where lower latency is more important than saving resource consumption when functions are idle.
 
-#### Diagram
-
 {{< img "../assets/newdeploy.png" "Fig.3 NewDeploy" "50em" "1" >}}
 
 1. Router asks the service address of a function.
@@ -129,5 +121,5 @@ Autoscaling is useful for workloads where you expect intermittent spikes in work
 It also enables optimal the usage of resources to execute functions, by using a baseline capacity with minimum scale and ability to burst up to maximum scale based on spikes in demand.
 
 {{% notice info %}}
-Learn more further usage/setup of **executor type** for functions, please see [here]({{% ref "../usage/function/executor.en.md" %}}).
+Refer to our documentation on [Controlling Function Execution]({{% ref "../usage/function/executor.en.md" %}}) to learn more about **executor type**.
 {{% /notice %}}

--- a/content/en/docs/architecture/function-pod.md
+++ b/content/en/docs/architecture/function-pod.md
@@ -5,8 +5,8 @@ description: >
   Place to load and execute the user function
 ---
 
-Function Pod is for serving HTTP requests from the clients.
-It contains two containers: 
+Function Pod serves HTTP requests received from the clients.
+It consists of two containers: 
 * Fetcher
 * Environment Container
 

--- a/content/en/docs/architecture/function-pod.md
+++ b/content/en/docs/architecture/function-pod.md
@@ -5,12 +5,19 @@ description: >
   Place to load and execute the user function
 ---
 
-## Brief Intro
-
 Function Pod is for serving HTTP requests from the clients.
-It contains two containers: Fetcher and Environment Container.
+It contains two containers: 
+* Fetcher
+* Environment Container
 
-## Diagram
+### Fetcher
+
+Fetcher is responsible to pull deployment archive from the [StorageSvc](/docs/architecture/storagesvc) and verify the checksum of file to ensure the integrity of file.
+
+### Environment Container
+
+Environment Container runs user-defined functions and is language-specific.
+Each environment container must contain an HTTP server and a loader for functions.
 
 {{< img "../assets/function-pod.png" "Fig.1 Function Pod" "50em" "1" >}}
 
@@ -20,12 +27,3 @@ It contains two containers: Fetcher and Environment Container.
 4. Call the specialized endpoint on the environment container to start function specialization.
 5. Environment Container loads the user function from the volume.
 6. Start serving the requests from Router.
-
-## Environment Container
-
-Environment Container runs user-defined functions and is language-specific.
-Each environment container must contain an HTTP server and a loader for functions.
-
-## Fetcher
-
-Fetcher is responsible to pull deployment archive from the StorageSvc and verify the checksum of file to ensure the integrity of file.

--- a/content/en/docs/architecture/kubewatcher.md
+++ b/content/en/docs/architecture/kubewatcher.md
@@ -8,10 +8,10 @@ description: >
 Kubewatcher watches the Kubernetes API and invokes functions associated with watches, sending the watch event to the function.
 
 The controller keeps track of the user's requested watches and associated functions.
-Kubewatcher watches the API based on these requests; when a watch event occurs, it serializes the object and calls the function via the [router](/docs/architecture/router  ).
+Kubewatcher watches the API based on these requests; when a watch event occurs, it serializes the object and calls the function via the [router](/docs/architecture/router).
 
 While a few simple retries are done, there isn't yet a reliable message bus between Kubewatcher and the function.
-Work for this is tracked in [issue #64](https://github.com/fission/fission.io/pull/64).
+Work for this is tracked in [issue #64](https://github.com/fission/fission/issues/64).
 
 {{< img "../assets/kubewatcher.png" "Fig.1 KubeWatcher Trigger" "30em" "1" >}}
 

--- a/content/en/docs/architecture/kubewatcher.md
+++ b/content/en/docs/architecture/kubewatcher.md
@@ -5,17 +5,13 @@ description: >
   Hawkeye to watch resource changes in Kubernetes cluster
 ---
 
-## Brief Intro
-
 Kubewatcher watches the Kubernetes API and invokes functions associated with watches, sending the watch event to the function.
 
 The controller keeps track of the user's requested watches and associated functions.
-Kubewatcher watches the API based on these requests; when a watch event occurs, it serializes the object and calls the function via the router.
+Kubewatcher watches the API based on these requests; when a watch event occurs, it serializes the object and calls the function via the [router](/docs/architecture/router  ).
 
 While a few simple retries are done, there isn't yet a reliable message bus between Kubewatcher and the function.
-Work for this is tracked in issue #64.
-
-## Diagram
+Work for this is tracked in [issue #64](https://github.com/fission/fission.io/pull/64).
 
 {{< img "../assets/kubewatcher.png" "Fig.1 KubeWatcher Trigger" "30em" "1" >}}
 

--- a/content/en/docs/architecture/logger.md
+++ b/content/en/docs/architecture/logger.md
@@ -5,12 +5,8 @@ description: >
   Record and persist function logs
 ---
 
-## Brief Intro
-
-Logger is deployed as DaemonSet to help to forward function logs to a centralized database service for log persistence.
+Logger is deployed as <a href="https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/" target="_blank">DaemonSet</a> to help to forward function logs to a centralized database service for log persistence.
 Currently, only InfluxDB is supported to store logs.
-
-## Diagram
 
 {{< img "../assets/logger.png" "Fig.1 Logger" "45em" "1" >}}
 

--- a/content/en/docs/architecture/message-queue-trigger.md
+++ b/content/en/docs/architecture/message-queue-trigger.md
@@ -5,14 +5,10 @@ description: >
   Subscribe topics and invoke functions
 ---
 
-## Brief Intro
-
 A message queue trigger binds a message queue topic to a function:
 
 Events from that topic cause the function to be invoked with the message as the body of the request.
 The trigger may also contain a response topic: if specified, the function's output is sent to this response.
-
-## Diagram
 
 {{< img "../assets/mqtrigger.png" "Fig.1 Message Queue Trigger" "45em" "1" >}}
 

--- a/content/en/docs/architecture/router.md
+++ b/content/en/docs/architecture/router.md
@@ -5,14 +5,10 @@ description: >
   Bridge between triggers and functions
 ---
 
-## Brief Intro
-
 The router forwards HTTP requests to function pods.
-If there's no running service for a function, it requests one from executor, while holding on to the request; the router will forward the request to the pod once the function service is ready.
+If there's no running service for a function, it requests one from [executor](/docs/architecture/executor), while holding on to the request; the router will forward the request to the pod once the function service is ready.
 
 The router is the only stateless component and can be scaled up if needed, according to load.
-
-## Diagram
 
 {{< img "../assets/router.png" "Fig.1 Router" "45em" "1" >}}
 

--- a/content/en/docs/architecture/storagesvc.md
+++ b/content/en/docs/architecture/storagesvc.md
@@ -5,13 +5,9 @@ description: >
   Home for source and deployment archives
 ---
 
-## Brief Intro
-
 The storage service is the home for all archives of packages with sizes larger than 256KB.
 The Builder pulls the source archive from the storage service and uploads deploy archive to it.
 The fetcher inside the function pod also pulls the deploy archive for function specialization.
-
-## Diagram
 
 {{< img "../assets/storagesvc.png" "Fig.1 StorageSvc" "50em" "1" >}}
 

--- a/content/en/docs/architecture/timer.md
+++ b/content/en/docs/architecture/timer.md
@@ -5,12 +5,8 @@ description: >
   Invoke functions periodically
 ---
 
-## Brief Intro
-
 The timer works like kubernetes CronJob but instead of creating a pod to do the task, it sends a request to router to invoke the function.
 It's suitable for the background tasks that need to execute periodically.
-
-## Diagram
 
 {{< img "../assets/timer.png" "Fig.1 Timer Trigger" "30em" "1" >}}
 

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -42,7 +42,7 @@ gathering dependencies.
 You can modify any of Fission's existing environments and rebuild them,
 or you can also build a new environment from scratch.
 
-See [here]({{% ref "../usage/languages/" %}}) for the full image list.
+Check out our complete list of [Fission Environments]({{% ref "../usage/languages/" %}}).
 
 ## Triggers
  


### PR DESCRIPTION
Fixed the following changes pertaining to links and readability of the documents as part of Issue #120:

-  https://fission.io/docs/concepts/ -> Environment -> can change the anchor text from "here" to "Fission Environments". Something like: Check out our complete list of Fission Environments.
- The text "Brief Intro", "Diagram" on every page should be removed, provides no extra info to the user nor for SEO
- Controller: The text "Kubernetes CRDs" - can be linked to https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/ - will provide better context to the reader
- Executor: PoolManager, NewDeploy - link to the relevant places on the page
- Function Pod: Fetcher & Environment Container - descriptions can be moved above the image
- Builder Pod: Fetcher & Builder container - descriptions can be moved above the image
- Logger: DaemonSets - can link to https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/ - - will provide better context to the reader
- Logger: links can be updated, for eg.: under Function Pod, we mention StorageSVC, but we have not mentioned it earlier. Hence we should link this to StorageSVC page or provide a small intro here.
- Kubewatcher: "Kubewatcher link to issue Add algolia search #64" - either add the link to the issue or remove the text.

Also, improved internal linking by linking to relevant pages.