### PR TITLE
Removed reference of fission-function and fission-builder namespace

### DIFF
--- a/content/en/blog/custom-metrics-autoscaling-new-deploy.md
+++ b/content/en/blog/custom-metrics-autoscaling-new-deploy.md
@@ -263,7 +263,7 @@ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/kafka/pods/%2A/
 
 ## Testing
 
-Run a producer function to send 10000 messages to the topic `request-topic` and check the namespace `fission-function` where the new deploy pods will be created or destroyed according to the metric value.
+Run a producer function to send 10000 messages to the topic `request-topic` and check the namespace `default` where the new deploy pods will be created or destroyed according to the metric value.
 
 ## Conclusion
 

--- a/content/en/blog/demystifying-fission-pool-manager.md
+++ b/content/en/blog/demystifying-fission-pool-manager.md
@@ -104,7 +104,7 @@ For instance, the below code snippet with create a new Python environment with a
 
 ```bash
 $ fission env create --name python --version **3** --poolsize **1** --image fission/python-env:latest
-$ kubectl -n fission-function get pod -l environmentName**=**test
+$ kubectl get pod -l environmentName**=**test
 ```
 
 To give you greater control over resource usages for all functions in the same environment, you can also set CPU and memory flags.

--- a/content/en/blog/fission-hello-world.md
+++ b/content/en/blog/fission-hello-world.md
@@ -97,11 +97,11 @@ Let’s create a **Go** environment using the following command:
 
 	fission env create --name go --image fission/go-env --builder fission/go-builder
 
->**NOTE**: _Since you are creating a new environment, it may take a few extra seconds before the Go environment pods are up and running in the fission-function namespace._
+>**NOTE**: _Since you are creating a new environment, it may take a few extra seconds before the Go environment pods are up and running in the default namespace._
 
 To verify if the pods are up and running, be sure to run this command:
 
-	$ kubectl get pods -n fission-function | grep go
+	$ kubectl get pods | grep go
 
 >_(The status of the pods should be "Running")_
 

--- a/content/en/blog/observability-with-opentelemetry-datadog-in-fission/index.md
+++ b/content/en/blog/observability-with-opentelemetry-datadog-in-fission/index.md
@@ -216,7 +216,7 @@ fission package create --name fissionoptel-pkg --sourcearchive sample.zip --env 
 
 > Note: The package creation process can take a long time especially while building `grpcio`, so plesae be patient.
 > You can check the progress of this using `stern`.
-> In a new terminal window, execute `stern '.*' -n fission-builder` to see the status of package creation.
+> In a new terminal window, execute `stern '.*'` to see the status of package creation.
 
 Create Fission function using the package created above:
 

--- a/content/en/blog/virus-scan-minio-fission-kafka-clamav/index.md
+++ b/content/en/blog/virus-scan-minio-fission-kafka-clamav/index.md
@@ -98,7 +98,7 @@ Replace ENDPOINT:PORT with a comma separated list of Kafka brokers
 
 ### Step 4 - Check the logs and Fission behaviour
 
-Your function will be deployed as pod in fission-function namespace into Kuberentes cluster.
+Your function will be deployed as pod in default namespace into Kuberentes cluster.
 Using kubectl logs -f -c python $POD_NAMEyou can check the logs in real time to see what happens there.
 Also, you have to take a look at Kafka topics (response or error) in order to know the output of your function.
 

--- a/content/en/docs/architecture/buildermgr.md
+++ b/content/en/docs/architecture/buildermgr.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 The builder manager watches the package & environments CRD changes and manages the builds of function source code.
-Once an environment that contains a builder  image is created, the builder manager will then create the Kubernetes service and deployment under the fission-builder namespace to start the environment builder.
+Once an environment that contains a builder  image is created, the builder manager will then create the Kubernetes service and deployment under the default namespace to start the environment builder.
 And once a package that contains a source archive is created, the builder manager talks to the environment builder to build the function's source archive into a deploy archive for function deployment.
 
 After the build, the builder manager asks Builder to upload the deploy archive to the Storage Service once the build succeeded, and updates the package status attached with build logs.

--- a/content/en/docs/installation/docker-desktop.md
+++ b/content/en/docs/installation/docker-desktop.md
@@ -51,7 +51,7 @@ This is because the HPA does not get actual consumption of pods and the value re
 This can be fixed by installing the metric server.
 
 ```bash
-$ kubectl get hpa -nfission-function
+$ kubectl get hpa
 NAME                                    REFERENCE                                          TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
 newdeploy-helloscale-default-ql0uqiwp   Deployment/newdeploy-helloscale-default-ql0uqiwp   <unknown>/50%   1         6         1          20h
 ```
@@ -93,7 +93,7 @@ docker-for-desktop   662m         16%    1510Mi          79%
 You will also notice that HPA has picked up the values from pod and now you can do autoscaling!
 
 ```bash
-$ kubectl get hpa -nfission-function
+$ kubectl get hpa
 NAME                                    REFERENCE                                          TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
 newdeploy-helloscale-default-gkxdkl8y   Deployment/newdeploy-helloscale-default-gkxdkl8y   20%/50%   1         6         1          48s
 ```

--- a/content/en/docs/reference/glossary.md
+++ b/content/en/docs/reference/glossary.md
@@ -35,7 +35,7 @@ Builder Container compiles function source code into executable binary/files and
 
 In a nutshell, the builder Manager manages the builds of function source code.
 
-Once an environment that contains a builder image is created, the builder manager will then create the Kubernetes service and deployment under the `fission-builder` namespace to start the environment builder. And once a package that contains a source archive is created, the builder manager talks to the environment builder to build the function’s source archive into a deploy archive for function deployment.
+Once an environment that contains a builder image is created, the builder manager will then create the Kubernetes service and deployment under the `default` namespace to start the environment builder. And once a package that contains a source archive is created, the builder manager talks to the environment builder to build the function’s source archive into a deploy archive for function deployment.
 
 ### Build Status
 

--- a/content/en/docs/trouble-shooting/setup/fission.md
+++ b/content/en/docs/trouble-shooting/setup/fission.md
@@ -81,7 +81,7 @@ Runtime is a container contains necessary language environment to run user funct
 You can filter out function pods you're interesting in and dump logs as follows.
 
 ```bash
-$ kubectl -n fission-function get pod -l functionName=<fn-name>
+$ kubectl get pod -l functionName=<fn-name>
 ```
 
 You can also add additional labels to filter out pods.
@@ -96,15 +96,15 @@ Here are some labels you can use.
 If you also want to filter out function pod in specific state like `RUNNING`, try:
 
 ```bash
-$ kubectl -n fission-function get pod -l functionName=<fn-name> \
+$ kubectl get pod -l functionName=<fn-name> \
     --field-selector status.phase=Running
 ```
 
 Dump logs from containers:
 
 ```bash
-$ kubectl -n fission-function describe pod -f <pod>
-$ kubectl -n fission-function logs -f <pod> -c <container>
+$ kubectl describe pod -f <pod>
+$ kubectl logs -f <pod> -c <container>
 ```
 
 #### Builder Pods
@@ -147,9 +147,9 @@ github.com/fission/fission/examples/go/go-module-example\n./main.go:4:2: importe
 To dump builder logs, you can do:
 
 ```bash
-$ kubectl -n fission-builder get pod -l envName=<env-name>
-$ kubectl -n fission-builder describe pod -f <pod>
-$ kubectl -n fission-builder logs -f <pod> -c <container>
+$ kubectl get pod -l envName=<env-name>
+$ kubectl describe pod -f <pod>
+$ kubectl logs -f <pod> -c <container>
 ```
 
 ### Dump Logs for Further Help

--- a/content/en/docs/usage/function/enabling-istio-on-fission.md
+++ b/content/en/docs/usage/function/enabling-istio-on-fission.md
@@ -99,7 +99,7 @@ executor-97c7fc96d-9tclp                                 2/2       Running      
 Also all function pods now have 3 containers - the function container, fetcher and now additionally the the istio-proxy container and we can see the istio-proxy logs for function containers.
 
 ```bash
-$ kubectl get pods -n fission-function
+$ kubectl get pods
 NAME                                                READY     STATUS    RESTARTS   AGE
 newdeploy-hello-default-mmrlkoog-557678fdcd-gw7tz   3/3       Running   2          9m
 poolmgr-node-default-esibbicv-65488fbc4d-2hdzc      3/3       Running   0          9m

--- a/content/en/docs/usage/function/executor.en.md
+++ b/content/en/docs/usage/function/executor.en.md
@@ -27,7 +27,7 @@ We may want to adjust the size of pools based on our need (e.g. resource efficie
 ```bash
 $ fission env create --name python --version 3 --poolsize 1 --image fission/python-env:latest
 
-$ kubectl -n fission-function get pod -l environmentName=test
+$ kubectl get pod -l environmentName=test
 ```
 
 Now, you shall see only one pod for the environment we just created.
@@ -196,7 +196,7 @@ This behavior is governed by the frequency at which the controller watches (whic
 More details can be found [here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-cooldowndelay)
 
 ```bash
-$ kubectl -n fission-function get hpa -w
+$ kubectl get hpa -w
 
 NAME             REFERENCE                   TARGETS      MINPODS   MAXPODS   REPLICAS   AGE
 hello-qoxmothj   Deployment/hello-qoxmothj   5% / 50%     1         6         1          3m

--- a/content/en/docs/usage/function/functions.en.md
+++ b/content/en/docs/usage/function/functions.en.md
@@ -229,10 +229,10 @@ $ fission route create --function hellopy --url /hellopy
 ```
 
 Once we create the function, the build process is started.
-You can check logs of the builder in fission-builder namespace:
+You can check logs of the builder in default namespace:
 
 ```bash
-$ kubectl -n fission-builder logs -f py3-4214348-59555d9bd8-ks7m4 builder
+$ kubectl logs -f py3-4214348-59555d9bd8-ks7m4 builder
 
 2018/02/16 11:44:21 Builder received request: {demo-src-pkg-zip-ninf-djtswo ./build.sh}
 2018/02/16 11:44:21 Starting build...

--- a/content/en/docs/usage/languages/go.md
+++ b/content/en/docs/usage/languages/go.md
@@ -523,7 +523,7 @@ So what's the reasonable resource setting for a function? It really depends on w
 Here's a tip, use `kubectl top` to get actual resource consumption of pod when doing benchmarking. Then you will know what's the best setting for a Go function.
 
 ```bash
-$ kubectl -n fission-function top pod -l functionName=g1
+$ kubectl top pod -l functionName=g1
 NAME                                                              CPU(cores)   MEMORY(bytes)
 go-1ef65ed0-d5eb-11e8-91e8-080027114863-9x7y4xmh-569bfdd9bhmlrf   112m           6Mi
 ```

--- a/content/en/docs/usage/observability/linkerd.md
+++ b/content/en/docs/usage/observability/linkerd.md
@@ -56,7 +56,7 @@ linkerd dashboard &
 
 ![Linkerd dashboard](../assets/linkerd-dashboard.png)
 
-- Under namespaces, select fission-function and check the existing deployments
+- Under namespaces, select default and check the existing deployments
 
 ![Linkerd before mesh](../assets/linkerd-before.png)
 
@@ -66,7 +66,7 @@ linkerd dashboard &
 Linkerd injects a side car proxy to add the deployment to it's data plane. We can do this at namespace level so that all deployments in a namespace are meshed.
 
 ```
-kubectl get -n  fission-function deploy -o yaml \
+kubectl get deploy -o yaml \
 | linkerd inject - \
 | kubectl apply -f -
 ```

--- a/content/en/docs/usage/spec/podspec/containers.md
+++ b/content/en/docs/usage/spec/podspec/containers.md
@@ -37,7 +37,7 @@ spec:
 We can see that the init container runs first, before the actual function containers run:
 
 ```bash
-$ kubectl -n fission-function get pod
+$ kubectl get pod
 NAME                                               READY     STATUS            RESTARTS   AGE
 poolmgr-python-default-9eik2gxd-6fdc8d9696-hkkgn   0/2       Init:0/1          0          10s
 poolmgr-python-default-9eik2gxd-6fdc8d9696-lpmgl   0/2       PodInitializing   0          10s
@@ -47,7 +47,7 @@ poolmgr-python-default-9eik2gxd-6fdc8d9696-tkmdc   0/2       PodInitializing   0
 And the init container here is simply printing the file which was mounted and we can verify the same by looking at logs of the init container:
 
 ```bash
-$ kubectl -n fission-function logs -f poolmgr-python-default-9eik2gxd-6fdc8d9696-lpmgl -c init-py
+$ kubectl logs -f poolmgr-python-default-9eik2gxd-6fdc8d9696-lpmgl -c init-py
 environmentName="python"
 environmentNamespace="default"
 environmentUid="68e3f909-3e86-11e9-9378-42010aa00057"

--- a/content/en/docs/usage/spec/podspec/envvar.md
+++ b/content/en/docs/usage/spec/podspec/envvar.md
@@ -32,7 +32,7 @@ spec:
 Now, you shall see the environment variable in container:
 
 ```sh
-$ kubectl -n fission-function exec -it <pod> -c fetcher sh
+$ kubectl exec -it <pod> -c fetcher sh
 / # env
 LOG_LEVEL=info
 ```
@@ -42,7 +42,7 @@ LOG_LEVEL=info
 Let's create a ConfigMap called `my-configmap`.
 
 ```bash
-$ kubectl -n fission-function create configmap my-configmap --from-literal=TEST_KEY="TESTVALUE"
+$ kubectl create configmap my-configmap --from-literal=TEST_KEY="TESTVALUE"
 ```
 
 And add PodSpec with `configMapKeyRef` to environment spec file.
@@ -65,7 +65,7 @@ spec:
 ```
 
 ```sh
-$ kubectl -n fission-function exec -it <pod> -c fetcher sh
+$ kubectl exec -it <pod> -c fetcher sh
 / # env
 TEST_KEY=TESTVALUE
 ```

--- a/content/en/docs/usage/spec/podspec/toleration.md
+++ b/content/en/docs/usage/spec/podspec/toleration.md
@@ -78,7 +78,7 @@ spec:
 Once we apply fission specs and run the function - you will notice that the pods go only on nodes with taints that match the toleration:
 
 ```bash
-$ kubectl -n fission-function get pod -o wide
+$ kubectl get pod -o wide
 NAME                                                 READY     STATUS    RESTARTS   AGE       IP             NODE
 newdeploy-pyfunc-default-kgsuik0l-66cd755675-jgjj6   2/2       Running   0          51s       10.16.177.16   gke-fission-dev-default-pool-87c8b616-549c
 poolmgr-python-default-okhvkdsv-57b866b774-hbz7q     2/2       Running   0          49s       10.16.176.34   gke-fission-dev-default-pool-87c8b616-5q2c

--- a/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/gcp-pub-sub.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/gcp-pub-sub.md
@@ -207,10 +207,10 @@ Messages in the GCP Pub/Sub response queue
 
 ## Debugging
 
-For debugging, you can check the logs of the pods created in the `fission` and `fission-function` namespace.
+For debugging, you can check the logs of the pods created in the `fission` and `default` namespace.
 
-Typically, all function pods would be created in the `fission-function` namespace.
-Based on the environment name, the pods would be created in the `fission-function` namespace.
+Typically, all function pods would be created in the `default` namespace.
+Based on the environment name, the pods would be created in the `default` namespace.
 You can check consumer and producer function logs.
 
 Try out the [Sample app](#sample-app) to see it in action.

--- a/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/kafka.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/kafka.md
@@ -273,10 +273,10 @@ There are a couple of ways you can verify that the consumer is called:
 
 ## Debugging
 
-For debugging, you can check the logs of the pods created in the `fission` and `fission-function` namespace.
+For debugging, you can check the logs of the pods created in the `fission` and `default` namespace.
 
-Typically, all function pods would be created in the `fission-function` namespace.
-Based on the environment name, the pods would be created in the `fission-function` namespace.
+Typically, all function pods would be created in the `default` namespace.
+Based on the environment name, the pods would be created in the `default` namespace.
 You can check consumer and producer function logs.
 
 ## Introducing an error

--- a/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/nats-jetstream.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/nats-jetstream.md
@@ -146,13 +146,13 @@ There are multiple ways to verify that the consumer function received the messag
 ```sh
 $ fission fn pod --name=helloworld
 NAME                                         NAMESPACE         READY  STATUS   IP            EXECUTORTYPE  MANAGED  
-poolmgr-go-default-6312601-6d6b85ff4f-b8m7g  fission-function  2/2    Running  10.244.0.188  poolmgr       false 
+poolmgr-go-default-6312601-6d6b85ff4f-b8m7g  default  2/2    Running  10.244.0.188  poolmgr       false 
 ```
 
 or
 
 ```sh
-$ kubectl -n fission-function get pod -l functionName=helloworld
+$ kubectl get pod -l functionName=helloworld
 NAME                                          READY   STATUS        RESTARTS   AGE
 poolmgr-go-default-6312601-6d6b85ff4f-b8m7g   2/2     Terminating   0          30m
 ```
@@ -160,7 +160,7 @@ poolmgr-go-default-6312601-6d6b85ff4f-b8m7g   2/2     Terminating   0          3
 Sample output:
 
 ```text
-$ kubectl -n fission-function logs -f -c go poolmgr-go-default-6312601-6d6b85ff4f-b8m7g 
+$ kubectl logs -f -c go poolmgr-go-default-6312601-6d6b85ff4f-b8m7g 
 2022/08/24 06:16:17 listening on 8888 ...
 2022/08/24 06:42:23 specializing ...
 2022/08/24 06:42:23 loading plugin from /userfunc/deployarchive/helloworld-eb3f240a-d6bb-4728-b806-f426ce0e255a-vyh8tf-oa1sgs

--- a/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/rabbitmq.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger-kind-keda/rabbitmq.md
@@ -328,10 +328,10 @@ poolmgr-go-default-3304406-8695f6fdd8-5jcx4 go 2022/01/21 06:55:27 Received mess
 
 ## Debugging
 
-For debugging, you can check the logs of the pods created in the `fission` and `fission-function` namespace.
+For debugging, you can check the logs of the pods created in the `fission` and `default` namespace.
 
-Typically, all function pods would be created in the `fission-function` namespace.
-Based on the environment name, the pods would be created in the `fission-function` namespace.
+Typically, all function pods would be created in the `default` namespace.
+Based on the environment name, the pods would be created in the `default` namespace.
 You can check consumer and producer function logs.
 
 Try out the [Sample app](#sample-app) to see it in action.


### PR DESCRIPTION
Starting from fission version v1.18.0, all fission resources will be created under default namespace until user has specified `functionNamsepace` and `builderNamespace` in helm chart explicitly. So we need to update fission doc accordingly.

This PR includes changes to remove reference of namespaces `fission-function` and `fission-builder` in fission doc.