### PR TITLE
Added metric reference for fission_mqt_message_lag

### DIFF
--- a/content/en/docs/reference/metrics-reference.md
+++ b/content/en/docs/reference/metrics-reference.md
@@ -24,3 +24,4 @@ To access these metrics, you'll need to install Fission 1.16 or higher.
 | fission_archive_memory_bytes | StorageSvc | Nil | Amount of memory consumed by archives |
 | fission_mqt_subscriptions | MqTrigger | Nil | Total number of subscriptions to mq currently |
 | fission_mqt_messages_processed_total | MqTrigger | trigger_name, trigger_namespace | Total number of messages processed by trigger |
+| fission_mqt_message_lag | MqTrigger | trigger_name, trigger_namespace, topic, partition | Total number of messages lag per topic and partition |


### PR DESCRIPTION
In fission v1.16.0, we have added new metric for MQT `fission_mqt_message_lag`. This metric will show total number of messages lag per topic and partition.

This PR  includes adding the reference for `fission_mqt_message_lag` in fission doc.