### PR TITLE
Add default nginx ingress class to the external route

### DIFF
--- a/content/en/docs/usage/ingress/_index.md
+++ b/content/en/docs/usage/ingress/_index.md
@@ -114,7 +114,7 @@ Now let's create a route which we will expose over ingress controller.
 We will create a route with `createingress` flag enabled:
 
 ```bash
-$ fission route create --url /hello --function hello --createingress
+$ fission route create --url /hello --function hello --createingress --ingressannotation "kubernetes.io/ingress.class=nginx"
 trigger '301b3cb0-5ac1-4211-a1ed-2b0ad9143e34' created
 
 $ fission route list


### PR DESCRIPTION
This pull request addresses an issue where creating an external route with NGINX Ingress on EKS was not working as expected due to the absence of an ingress class annotation. This change makes it clear that specifying the 'nginx' class as the default is necessary for the Ingress to function correctly.