### PR TITLE
Release notes and docs update for release v1.20.5

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -111,7 +111,7 @@ privacy_policy = ""
 # current release branch - could be rc
 release_branch = "main"
 # the main version. Never is rc.
-release_version = "v1.20.4"
+release_version = "v1.20.5"
 
 slackurl = "/slack"
 

--- a/content/en/docs/installation/_index.en.md
+++ b/content/en/docs/installation/_index.en.md
@@ -65,6 +65,11 @@ With 1.18 release, fission watches functions created in `defaultNamespace` menti
 Refer [1.18 release notes]({{< ref "v1.18.0.md" >}}) for more details.
 {{< /notice >}}
 
+{{< notice warning >}}
+`builderNamespace` and `functionNamespace` parameters are deprecated and will be removed in future fission releases.
+`disableOwnerReference` flag is temporary addition and would be removed in future fission releases.
+{{< /notice >}}
+
 {{< notice info>}}
 serviceType, routerServiceType can be `NodePort` or `LoadBalancer` for external access to Fission in below steps.
 You can use `ClusterIP` if you want to access Fission from within the cluster.

--- a/content/en/docs/reference/crd-reference.md
+++ b/content/en/docs/reference/crd-reference.md
@@ -73,6 +73,10 @@ externally.
 _Appears in:_
 - [Archive](#archive)
 
+| Field | Description |
+| --- | --- |
+| `literal` | ArchiveTypeLiteral means the package contents are specified in the Literal field of<br />resource itself.<br /> |
+| `url` | ArchiveTypeUrl means the package contents are at the specified URL.<br /> |
 
 
 
@@ -200,6 +204,9 @@ sha256, used for a checksum.
 _Appears in:_
 - [Checksum](#checksum)
 
+| Field | Description |
+| --- | --- |
+| `sha256` |  |
 
 
 #### ConfigMapReference
@@ -327,6 +334,11 @@ ExecutorType is the primary executor for an environment
 _Appears in:_
 - [ExecutionStrategy](#executionstrategy)
 
+| Field | Description |
+| --- | --- |
+| `poolmgr` |  |
+| `newdeploy` |  |
+| `container` |  |
 
 
 #### FailureType
@@ -340,6 +352,9 @@ FailureType refers to the type of failure
 _Appears in:_
 - [CanaryConfigSpec](#canaryconfigspec)
 
+| Field | Description |
+| --- | --- |
+| `status-code` | failure type currently supported is http status code. This could be extended<br />in the future.<br /> |
 
 
 #### Function

--- a/content/en/docs/releases/v1.20.5.md
+++ b/content/en/docs/releases/v1.20.5.md
@@ -25,7 +25,7 @@ With 1.20.3 release, support for architecture `armv7` has been removed. Now Fiss
 * Remove useless arguments when the function is updated. [3010](https://github.com/fission/fission/pull/3010)
 * Fix error handling in package update logic implementation. [3012](https://github.com/fission/fission/pull/3012)
 * Fix the error printing in error handling. [3013](https://github.com/fission/fission/pull/3013)
-* Fixed the error while printing pod logs when the function retuns status 404. [3021](https://github.com/fission/fission/pull/3021)
+* Fixed the error while printing pod logs when the function returns status 404. [3021](https://github.com/fission/fission/pull/3021)
 * Fixed the builder container's error while cleaning src packages. [3031](https://github.com/fission/fission/pull/3031)
 
 ## Updates

--- a/content/en/docs/releases/v1.20.5.md
+++ b/content/en/docs/releases/v1.20.5.md
@@ -1,0 +1,59 @@
+---
+title: "v1.20.5"
+linkTitle: v1.20.5
+weight: 73
+---
+
+{{< notice warning >}}
+With 1.20.3 release, support for architecture `armv7` has been removed. Now Fission supports `arm64` and `amd64` architectures only.
+{{< /notice >}}
+
+## Features
+
+### Time Trigger Changes
+
+- The Timer now supports invoking a Fission function using the following HTTP methods: GET, POST, PUT, DELETE, and HEAD. Additionally, a subpath flag can be used if the function supports internal routing. [#2996](https://github.com/fission/fission/pull/2996)
+
+## Fixes
+
+### Cross Namespaces `builderNamespace` and `functionNamespace`
+
+- Fixed issues with cross namespaces because of OwnerReference field set to K8s resources created by Fission. Introduced a new flag to disable OwnerReferences when using cross namespaces. [3026](https://github.com/fission/fission/pull/3026)
+
+### Miscellaneous fixes
+
+* Remove useless arguments when the function is updated. [3010](https://github.com/fission/fission/pull/3010)
+* Fix error handling in package update logic implementation. [3012](https://github.com/fission/fission/pull/3012)
+* Fix the error printing in error handling. [3013](https://github.com/fission/fission/pull/3013)
+* Fixed the error while printing pod logs when the function retuns status 404. [3021](https://github.com/fission/fission/pull/3021)
+* Fixed the builder container's error while cleaning src packages. [3031](https://github.com/fission/fission/pull/3031)
+
+## Updates
+
+* Use typed rate limiting queue. [3028](https://github.com/fission/fission/pull/3028)
+* Go version has been updated to `v1.23.1`. [3027](https://github.com/fission/fission/pull/3027)
+* Updated Keda-connectors version and go packages. [3029](https://github.com/fission/fission/pull/3029)
+
+## Changelog
+
+* [21bccdae](https://github.com/fission/fission/commit/21bccdae) Bump github.com/opencontainers/runc from 1.1.12 to 1.1.14 [3008](https://github.com/fission/fission/pull/3008)
+* [5cdecefc](https://github.com/fission/fission/commit/5cdecefc) Fixed: Remove useless arguments when the function is updated [3010](https://github.com/fission/fission/pull/3010)
+* [1f41de99](https://github.com/fission/fission/commit/1f41de99) Fix error handling in package update logic implementation [3012](https://github.com/fission/fission/pull/3012)
+* [5d580e01](https://github.com/fission/fission/commit/5d580e01) Fix the error printing in error handling [3013](https://github.com/fission/fission/pull/3013)
+* [93869d3b](https://github.com/fission/fission/commit/93869d3b) Add method and subpath flags to timetrigger object for triggering a function [3017](https://github.com/fission/fission/pull/3017)
+* [b8f746cb](https://github.com/fission/fission/commit/b8f746cb) Fixed: Print pod log error when response status is 404 returned by te… [3021](https://github.com/fission/fission/pull/3021)
+* [2bf00025](https://github.com/fission/fission/commit/2bf00025) Fixed: Allow to disable owner references for cross namespace access with builder and function namespace [3024](https://github.com/fission/fission/pull/3024)
+* [2db9db0b](https://github.com/fission/fission/commit/2db9db0b) Fix slice init length in fetcher pod spec addition [3018](https://github.com/fission/fission/pull/3018)
+* [687a84a2](https://github.com/fission/fission/commit/687a84a2) Update codeql action version to 3.26.9 [3025](https://github.com/fission/fission/pull/3025)
+* [2f8ad166](https://github.com/fission/fission/commit/2f8ad166) Warning: Deprecation warning for cross namespace parameters [3026](https://github.com/fission/fission/pull/3026)
+* [9bdac9a3](https://github.com/fission/fission/commit/9bdac9a3) Upgraded to Go latest version 1.23.1 [3027](https://github.com/fission/fission/pull/3027)
+* [15857b02](https://github.com/fission/fission/commit/15857b02) Use typed rate limiting queue [3028](https://github.com/fission/fission/pull/3028)
+* [4b76ec90](https://github.com/fission/fission/commit/4b76ec90) Update Keda-connectors version and go packages [3029](https://github.com/fission/fission/pull/3029)
+* [db2b0ad4](https://github.com/fission/fission/commit/db2b0ad4) Fixed: builder container has error logs for cleaning src packages [3031](https://github.com/fission/fission/pull/3031)
+* [352090d0](https://github.com/fission/fission/commit/352090d0) Updated app version and chart version to v1.20.5 [3032](https://github.com/fission/fission/pull/3032)
+
+## References
+
+- [Environments](/environments/)
+- [Custom Resource Definition Specification](https://doc.crds.dev/github.com/fission/fission)
+- [Releases](https://github.com/fission/fission/releases)

--- a/tools/notes.py
+++ b/tools/notes.py
@@ -1,3 +1,46 @@
+import requests
+import re
+
+repo_owner = 'fission'
+repo_name = 'fission'
+
+def remove_author_info(input_string):
+    """
+    Remove the 'by @username in' substring from the input string.
+
+    :param input_string: The original string.
+    :return: The modified string without the author information.
+    """
+    # Use regex to match ' by @username in' where username can be alphanumeric and contain dashes
+    modified_string = re.sub(r' by @[a-zA-Z0-9-]+ in', '', input_string)
+
+    # Strip leading and trailing whitespace
+    return modified_string.strip()
+
+def get_merged_pr_commit_sha(repo_owner, repo_name, pr_number):
+    """
+    Get the commit SHA of a merged pull request from a public repository.
+
+    :param repo_owner: The owner of the repository (GitHub username or organization).
+    :param repo_name: The name of the repository.
+    :param pr_number: The number of the pull request.
+    :return: Commit SHA if PR is merged, otherwise None.
+    """
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
+
+    response = requests.get(url)
+
+    if response.status_code == 200:
+        pr_data = response.json()
+        if pr_data['merged_at']:  # Check if the PR is merged
+            return pr_data['merge_commit_sha']
+        else:
+            print("Pull request is not merged.")
+    else:
+        print(f"Failed to retrieve PR: {response.status_code} - {response.text}")
+
+    return None
+
 def read_file(file_name):
     """Read content from a file and return the content as a string."""
     with open(file_name, 'r') as f:
@@ -7,15 +50,19 @@ def format_commit_and_pull_link(line):
     """Format the commit and pull link based on the provided line."""
     cols = line.split(' ')
     if len(cols) > 2:
+        pull_number = cols[-1].lstrip('#')
+        commit = get_merged_pr_commit_sha(repo_owner=repo_owner, repo_name=repo_name, pr_number=pull_number)
         # Format commit link
-        cols[1] = "[{0}](https://github.com/fission/fission/commit/{0})".format(cols[1])
+        commit_link = "[{0}](https://github.com/fission/fission/commit/{0})".format(commit[:8])
 
-        # Extract pull number, format and replace in the column
-        pull_number = cols[-1].strip('()')
+        # Put pull number, format and replace in the column
         formatted_pull_link = "[{0}](https://github.com/fission/fission/pull/{1})".format(pull_number, pull_number.replace('#', ''))
         cols[-1] = formatted_pull_link
+        cols = ' '.join(cols)
+        cols = remove_author_info(cols)
 
-        return ' '.join(cols)
+        return '* ' + commit_link + ' ' + cols
+
     return line
 
 def main():


### PR DESCRIPTION
- Added release notes for release `v1.20.5`.
- Modified `tools/notes.py` to make it work with github generated release notes.