### PR TITLE
fix typo in Architecture for Builder Pod

### DIFF
--- a/content/en/docs/architecture/_index.md
+++ b/content/en/docs/architecture/_index.md
@@ -32,7 +32,7 @@ Place to load and execute the user function
 Compile the source code into a runnable function
 
 ### [Builder Pod](builder-pod)
-Place to load and execute the user function
+Place to load and create the user function
 
 ### [StorageSvc](storagesvc)
 Home for source and deployment archives

--- a/content/en/docs/architecture/_index.md
+++ b/content/en/docs/architecture/_index.md
@@ -32,7 +32,7 @@ Place to load and execute the user function
 Compile the source code into a runnable function
 
 ### [Builder Pod](builder-pod)
-Place to load and create the user function
+Place to build and create executable user function
 
 ### [StorageSvc](storagesvc)
 Home for source and deployment archives


### PR DESCRIPTION
- This will help reduce the initial confusion when looking at the Core Components listing and users seeing that both Builder and Function Pods allow executing a function - ONLY Function Pods allow executing.