### PR TITLE
Doc changes v1.23.0

### DIFF
--- a/.claude/skills/bumping-hugo-docsy-site/SKILL.md
+++ b/.claude/skills/bumping-hugo-docsy-site/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: bumping-hugo-docsy-site
+description: Use when bumping Hugo, Go, or Docsy theme versions in this Hugo+Docsy site (theme loaded as a Hugo Module via go.mod, pinned in netlify.toml). Triggers include "update go version", "bump docsy", "upgrade hugo", or stale GO_VERSION/HUGO_VERSION in netlify.toml.
+---
+
+# Bumping a Hugo + Docsy + Netlify Site
+
+## Overview
+
+Versions are pinned in **three** places that must stay in sync: `go.mod` (Go directive + module require), `netlify.toml` (GO_VERSION + HUGO_VERSION across every `[context.*]`), and the Docsy module version itself.
+The non-obvious trap: **`go mod tidy` strips the Docsy `require` lines** because no Go source imports them — Hugo's module system uses go.mod but Go's tooling can't see that. Use `hugo mod get` for module updates, not `go get` + `go mod tidy`.
+
+## When to Use
+
+- Routine version refresh on this site.
+- User asks to "update Go", "bump Docsy", or "upgrade Hugo".
+- Indicators: `[module]` block with `path = "github.com/google/docsy"` in `config.toml`, and `GO_VERSION`/`HUGO_VERSION` in `netlify.toml`.
+
+## Quick Reference
+
+| Version | Where pinned | How to update |
+|---|---|---|
+| Docsy theme | `go.mod` `require` | `hugo mod get github.com/google/docsy@vX.Y.Z` |
+| Docsy dependencies | `go.mod` `require` | `hugo mod get github.com/google/docsy/dependencies@vX.Y.Z` |
+| Go toolchain (directive) | `go.mod` `go ...` line | `go mod edit -go=X.Y.Z` |
+| Go toolchain (Netlify) | `netlify.toml` `GO_VERSION` in every context | manual edit |
+| Hugo (Netlify) | `netlify.toml` `HUGO_VERSION` in every context | manual edit |
+
+## Procedure
+
+### 1. Check the current state
+
+```bash
+cat go.mod
+grep -E '(HUGO|GO)_VERSION' netlify.toml
+go version    # local Go
+hugo version  # local Hugo (extended build expected)
+```
+
+### 2. Look up the latest versions
+
+```bash
+# Docsy + dependencies — go module proxy is authoritative
+curl -s https://proxy.golang.org/github.com/google/docsy/@latest
+curl -s https://proxy.golang.org/github.com/google/docsy/dependencies/@latest
+
+# Latest Hugo release
+curl -sL https://api.github.com/repos/gohugoio/hugo/releases/latest | grep '"tag_name"'
+```
+
+Note: `docsy/dependencies` moves rarely — pinned at `v0.7.2` since 2023.
+Don't assume it has an update just because the main Docsy module does.
+
+### 3. Update Docsy via `hugo mod get` (NOT `go get` + `go mod tidy`)
+
+```bash
+hugo mod get github.com/google/docsy@vX.Y.Z
+hugo mod get github.com/google/docsy/dependencies@vA.B.C   # only if changed
+```
+
+**Why not `go mod tidy`:** It scans Go source files for imports. There are none for the theme — Hugo resolves modules at build time. `tidy` will silently strip both `require` lines, leaving an empty `go.mod` that Hugo then refuses to build against.
+`hugo mod get` writes both `go.mod` and `go.sum` correctly.
+
+If you already ran `go mod tidy` and lost the requires, recover with the same `hugo mod get` calls — they re-add them.
+
+### 4. Bump the Go directive in go.mod
+
+```bash
+go mod edit -go=X.Y.Z   # match local `go version` or Netlify's GO_VERSION
+```
+
+### 5. Sync netlify.toml
+
+Update **every** `[context.*]` block (currently `production`, `split1`, `deploy-preview`, `branch-deploy`):
+
+```toml
+HUGO_VERSION = "<new-hugo-version>"
+GO_VERSION   = "<matches go.mod go directive>"
+```
+
+Easy to miss: the same pair is repeated 4× — use a single multi-line `Edit` covering all contexts, not four separate edits.
+
+### 6. Verify the build locally
+
+```bash
+hugo --gc --quiet && echo OK
+```
+
+Exit 0 with no output = clean.
+If templates broke on a Docsy major bump, read the Docsy release notes — partials/shortcodes occasionally rename.
+
+### 7. Review and commit
+
+```bash
+git diff --stat
+git diff go.mod go.sum netlify.toml
+```
+
+Expect changes only in `go.mod`, `go.sum`, `netlify.toml`.
+If `public/` or `resources/_gen/` show up they're build artifacts — `.gitignore` already excludes them, don't add them.
+
+## Common Mistakes
+
+| Mistake | Symptom | Fix |
+|---|---|---|
+| Ran `go mod tidy` after `go get` | `go.mod` requires section is empty | Re-run `hugo mod get` for each module |
+| Bumped `GO_VERSION` in only one context | Production deploys on old Go, previews on new (or vice versa) | Update all 4 contexts |
+| Bumped `HUGO_VERSION` in netlify but not the `go.mod` `go` directive | Local build uses different toolchain than CI | Keep them aligned |
+| Used `go get` instead of `hugo mod get` | Works, but doesn't refresh Hugo's module cache the same way | Prefer `hugo mod get` |
+| Pinned Hugo to non-extended version | SCSS/asset pipeline breaks | Docsy needs Hugo **extended** — Netlify's image is extended by default |
+
+## Red Flags — Stop
+
+- About to run `go mod tidy` after touching a module require → don't.
+- About to commit only `go.mod` without `go.sum` or vice versa → both update together.
+- `hugo --gc` prints warnings about missing partials after a Docsy major bump → check Docsy CHANGELOG before pushing.
+- `netlify.toml` diff touches only one context → check the others.

--- a/.claude/skills/bumping-hugo-docsy-site/SKILL.md
+++ b/.claude/skills/bumping-hugo-docsy-site/SKILL.md
@@ -37,16 +37,22 @@ go version    # local Go
 hugo version  # local Hugo (extended build expected)
 ```
 
-### 2. Look up the latest versions
+### 2. Look up the right versions
 
 ```bash
 # Docsy + dependencies — go module proxy is authoritative
 curl -s https://proxy.golang.org/github.com/google/docsy/@latest
 curl -s https://proxy.golang.org/github.com/google/docsy/dependencies/@latest
-
-# Latest Hugo release
-curl -sL https://api.github.com/repos/gohugoio/hugo/releases/latest | grep '"tag_name"'
 ```
+
+**Hugo: pin to whatever Docsy itself targets, NOT the absolute latest Hugo release.**
+Docsy's `package.json` carries a `hugo_version` field that records the Hugo version that release was tested against:
+
+```bash
+gh api "repos/google/docsy/contents/package.json?ref=v<docsy-version>" --jq .content | base64 -d | grep -A1 hugo_version
+```
+
+Bumping Hugo past that pin risks breakage. Specifically: Hugo 0.158+ wraps the PostCSS pipeline in Node's experimental Permission Model with a restricted filesystem scope, which breaks browserslist's parent-directory search and hangs/fails `hugo --minify`. Docsy v0.15.0 pins `hugo_version: "0.157.0"` (the last pre-permission-model release) for exactly this reason.
 
 Note: `docsy/dependencies` moves rarely — pinned at `v0.7.2` since 2023.
 Don't assume it has an update just because the main Docsy module does.
@@ -83,10 +89,11 @@ Easy to miss: the same pair is repeated 4× — use a single multi-line `Edit` c
 ### 6. Verify the build locally
 
 ```bash
-hugo --gc --quiet && echo OK
+./build.sh   # the full production command — matches what Netlify runs
 ```
 
-Exit 0 with no output = clean.
+**Don't shortcut with `hugo --gc --quiet`.** It bypasses `--minify`, which is what triggers the PostCSS pipeline (and any Hugo/Docsy/Node-permission-model interactions). Always run the same flags Netlify will run: `hugo --minify --printPathWarnings --gc`.
+
 If templates broke on a Docsy major bump, read the Docsy release notes — partials/shortcodes occasionally rename.
 
 ### 7. Review and commit
@@ -104,6 +111,8 @@ If `public/` or `resources/_gen/` show up they're build artifacts — `.gitignor
 | Mistake | Symptom | Fix |
 |---|---|---|
 | Ran `go mod tidy` after `go get` | `go.mod` requires section is empty | Re-run `hugo mod get` for each module |
+| Pinned Hugo to the absolute latest release | `hugo --minify` hangs or errors with `ERR_ACCESS_DENIED` / "Access to this API has been restricted" from Node | Pin to whatever Docsy's `package.json` `hugo_version` field says |
+| Verified with `hugo --gc --quiet` only | "Looked clean locally" but Netlify fails | Run `./build.sh` — it uses `--minify` which is what exercises the PostCSS pipeline |
 | Bumped `GO_VERSION` in only one context | Production deploys on old Go, previews on new (or vice versa) | Update all 4 contexts |
 | Bumped `HUGO_VERSION` in netlify but not the `go.mod` `go` directive | Local build uses different toolchain than CI | Keep them aligned |
 | Used `go get` instead of `hugo mod get` | Works, but doesn't refresh Hugo's module cache the same way | Prefer `hugo mod get` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+Source for [fission.io](https://fission.io), the marketing/docs site for the Fission serverless platform.
+It is a [Hugo](https://gohugo.io) static site using the [Docsy](https://github.com/google/docsy) theme, deployed to Netlify.
+This repo contains **no Fission product code** — that lives at https://github.com/fission/fission.
+Work here is almost always content edits (Markdown under `content/en/`), template/asset tweaks (`layouts/`, `assets/scss/`, `static/`), or release-version bumps in `config.toml`.
+
+## Build, serve, and deploy
+
+- `npm install` — install PostCSS toolchain (autoprefixer for the Docsy theme).
+- `hugo server` — local preview on http://localhost:1313/.
+- `./build.sh` — what Netlify runs (`hugo --minify --printPathWarnings --gc`).
+- Netlify pins exact versions in `netlify.toml`: **Hugo 0.152.2** (extended) and **Go 1.25.5**.
+Match these locally when reproducing CI builds — Hugo behavior differs across versions.
+- The Docsy theme is pulled as a **Hugo Module** via `go.mod` (`github.com/google/docsy`), not a git submodule.
+The `.gitmodules` file is empty and the `git submodule update` line in `CONTRIBUTING.md` is stale — ignore it.
+- There are no unit tests. CI (`.github/workflows/main.yml`) runs reviewdog misspell + languagetool on changed `*.md` files only.
+
+## Content architecture
+
+All site content is under `content/en/` (single language, `defaultContentLanguage = "en"` in `config.toml`):
+
+- `docs/` — versioned product documentation (architecture, concepts, installation, usage, reference, releases, trouble-shooting, contributing).
+- `blog/` — blog posts; permalink scheme is `/blog/:slug/` (set in `config.toml` `[permalinks]`).
+- `environments/`, `examples/`, `support/`, `author/` — top-level sections wired into the main menu in `config.toml`.
+- `_index.html` is the landing page; many of its content blocks come from `[params]` in `config.toml` (`whatsnew` cards, hero links, etc.) rather than from Markdown.
+
+Authoring conventions worth knowing:
+
+- **Front matter** sets ordering via `weight:` and can opt a page out of features (`hide_feedback: true`, `hide_readingtime: true`).
+- **Use the version shortcodes**, never hardcode versions in docs:
+  - `{{< release-version >}}` → emits `params.release_version` (e.g. `v1.22.0`)
+  - `{{< chart-version >}}` → emits `params.chart_version` (e.g. `1.22.1`)
+  Both are defined in `config.toml` and rendered by `layouts/shortcodes/release-version.html` and `chart-version.html`.
+- Other custom shortcodes live in `layouts/shortcodes/` (`tabs`, `tab`, `notice`, `img`, `readfile`, `relref`).
+- `[markup.goldmark.renderer] unsafe = true` is set, so raw HTML in Markdown renders — this is intentional for the Docsy templates.
+
+## Release bumps
+
+When cutting a Fission release, two values in `config.toml` change independently (see commit `ef1ea56` "Separate app and chart version"):
+
+- `release_version` — Fission app version (drives `{{< release-version >}}`, install docs, etc.).
+- `chart_version` — Helm chart version (drives `{{< chart-version >}}`).
+
+These are decoupled because the chart can revision without an app release.
+Don't assume they move together.
+
+## Redirects and URL stability
+
+`netlify.toml` carries a long list of historical redirects (`/latest/*`, `/0.2.1/*`, `/0.4.0/*`, …) preserving old documentation URLs.
+When renaming or moving a docs page, add a redirect rather than breaking inbound links.
+
+## Helper scripts (`tools/`)
+
+Python scripts run manually, not in CI:
+
+- `tools/environments.py` — regenerates `static/data/environments.json` from an upstream `environments.json` copied in from the `fission/environments` repo.
+Required when adding a new language environment to the site.
+See `tools/README.md` for the env-dict mapping step.
+- `tools/notes.py` — formats draft-release changelog text (paste into `notes.txt` first) for inclusion in `content/en/docs/releases/`.
+
+## Markdown style
+
+Treat each sentence as its own line within paragraphs (CommonMark renders single newlines as spaces, so HTML output is unchanged but diffs become per-sentence).
+Don't rewrap whole paragraphs when changing one sentence.

--- a/config.toml
+++ b/config.toml
@@ -111,8 +111,8 @@ privacy_policy = ""
 # current release branch - could be rc
 release_branch = "main"
 # the main version. Never is rc.
-release_version = "v1.22.0"
-chart_version = "1.22.1"
+release_version = "v1.23.0"
+chart_version = "1.23.0"
 
 slackurl = "/slack"
 

--- a/content/en/docs/installation/internal-auth.md
+++ b/content/en/docs/installation/internal-auth.md
@@ -1,0 +1,129 @@
+---
+title: "Internal Service Authentication"
+weight: 45
+description: >
+  HMAC-signed authentication for Fission's internal control-plane RPCs
+---
+
+Starting with [v1.23.0](/docs/releases/v1.23.0/), Fission ships **application-layer HMAC authentication** for the internal HTTP channels between its control-plane services.
+This is distinct from the end-user [function-invocation authentication](/docs/installation/authentication/) (JWT, opt-in): internal auth protects in-cluster RPCs and is **enabled by default**.
+
+## What it protects
+
+Five internal channels now require signed requests when `internalAuth.enabled=true`:
+
+| Service | Server endpoint(s) | Callers |
+|---|---|---|
+| `storagesvc` | `/v1/archive` | controllers uploading function archives |
+| `fetcher` (per-pod sidecar) | `/fetch`, `/upload`, `/clean`, `/specialize` | buildermgr, executor |
+| `builder` (per-pod) | `/build` | buildermgr |
+| `executor` | `/v2/getServiceForFunction`, `/v2/tap`, `/v2/error`, … | router, kubewatcher, timer, mqt-fission-kafka, canaryconfig |
+| `router-internal` (port `8889`) | `/fission-function/<ns>/<name>` | executor, kubewatcher, timer, mqt-fission-kafka |
+
+Each pair derives a per-service key via HKDF from a single chart-managed master secret, so one toggle gates all five channels atomically.
+
+## Key behavioral change in v1.23.0
+
+The router now binds **two listeners**:
+
+- **Public listener** (port `8888`) — serves user `HTTPTrigger` paths, `/router-healthz`, `/_version`, and (when enabled) the JWT-based [function-invocation auth](/docs/installation/authentication/).
+- **Internal listener** (port `8889`) — serves `/fission-function/<ns>/<name>` only, gated by `NetworkPolicy` plus HMAC verification.
+
+**`/fission-function/<ns>/<name>` no longer exists on the public listener.** This closes [GHSA-3g33-6vg6-27m8](https://github.com/fission/fission/security/advisories/GHSA-3g33-6vg6-27m8) — previously anyone reachable to the public router URL (e.g. via Ingress) could invoke any function by guessing its name, bypassing all `HTTPTrigger` host/path/method gates.
+
+Any external tooling that today curls `/fission-function/...` against the public router URL will receive **404** after upgrading.
+The public listener is unchanged for user `HTTPTrigger` traffic.
+
+## Default install
+
+`internalAuth.enabled` defaults to `true` from v1.23.0 onwards:
+
+```bash
+helm install fission fission-charts/fission-all -n fission --create-namespace
+```
+
+The chart materialises a `Secret/fission-internal-auth` with an auto-generated 32-byte master key.
+The same value is preserved across `helm upgrade` runs.
+Every controller, executor, router, and dynamically-created builder/function pod mounts the master via environment variable; each signer/verifier pair derives its own per-service key.
+
+## Bring your own master secret
+
+```bash
+helm install fission fission-charts/fission-all -n fission \
+  --set internalAuth.secret="$(openssl rand -base64 32)"
+```
+
+If `internalAuth.secret` is set, the chart honours it instead of auto-generating one.
+
+## Disable everywhere
+
+```bash
+helm install fission fission-charts/fission-all -n fission \
+  --set internalAuth.enabled=false
+```
+
+With `enabled=false` the chart skips the `Secret` and the env mounts.
+Every signer/verifier short-circuits to pass-through — no signing, no verification — so the cluster falls back to `NetworkPolicy` + namespace isolation alone for in-cluster trust.
+
+This is the **recommended setting if you rely on stock upstream KEDA connector images** (`fission/kafka-http-connector` and friends) — see [Caveats](#caveats) below.
+
+The router's two-listener split is independent of this toggle: `/fission-function/<ns>/<name>` remains on the internal listener regardless.
+With `internalAuth.enabled=false` the internal listener still accepts unsigned requests; with `internalAuth.enabled=true` it requires signatures.
+
+## Master-secret rotation
+
+The master secret can be rotated without downtime using the `oldSecret` overlap field:
+
+```bash
+# Step 1 — pin the live secret as `oldSecret` so verifiers accept both.
+LIVE=$(kubectl -n fission get secret fission-internal-auth -o jsonpath='{.data.secret}' | base64 -d)
+helm upgrade fission fission-charts/fission-all -n fission \
+  --set internalAuth.oldSecret="$LIVE"
+
+# Step 2 — roll in the new master.
+helm upgrade fission fission-charts/fission-all -n fission \
+  --set internalAuth.secret="$(openssl rand -base64 32)"
+
+# Step 3 — wait for every Fission deployment to finish rolling.
+
+# Step 4 — drop the old secret.
+helm upgrade fission fission-charts/fission-all -n fission \
+  --set internalAuth.oldSecret=""
+```
+
+Because every per-service key is derived from the master via HKDF, this single sequence rotates the key for all five channels atomically.
+
+## Toggle interaction matrix
+
+| Server (verifier) | Client (signer) | Outcome |
+|---|---|---|
+| OFF | OFF | All requests pass through unsigned — identical to pre-v1.23 in-cluster behaviour |
+| ON | ON | All signed and verified per-service (default) |
+| ON | OFF | Client request returns **401** |
+| OFF | ON | Client sends signed headers; server pass-through ignores them — works |
+
+The chart applies the toggle wholesale, so the "ON / OFF" failure mode only surfaces during hand-edited deployments, in-flight `helm upgrade` rollouts where some pods haven't rolled yet, or external tooling that signed against an unconfigured CLI.
+
+## Caveats
+
+### KEDA connector signing gap
+
+Upstream `fission/kafka-http-connector` (and the other Fission KEDA connector images) **do not yet sign their `/fission-function/...` invocations**.
+With `internalAuth.enabled=true` (the default), KEDA-driven message-queue triggers will receive `401` from the router internal listener.
+
+Operators have two options until signing-aware KEDA images ship:
+
+1. **Build signing-aware connector images** (recommended long-term). The signer primitive lives in `pkg/auth/hmac` in the Fission repo.
+2. **Set `internalAuth.enabled=false`** and rely on `NetworkPolicy` alone for the KEDA traffic. The internal listener still hosts `/fission-function/<ns>/<name>` but does not enforce signatures.
+
+### `ROUTER_INTERNAL_URL`
+
+Services that publish to the router internal listener (`kubewatcher`, `timer`, `mqt-fission-kafka`, `mqt-keda`) now read `ROUTER_INTERNAL_URL`.
+The chart sets it to `http://router.fission.svc:8889` by default.
+If you customise the router `Service` name, namespace, or `router.internalPort`, set this env override accordingly.
+
+## Reference
+
+- [GHSA-3g33-6vg6-27m8](https://github.com/fission/fission/security/advisories/GHSA-3g33-6vg6-27m8) — router public-listener function-invocation exposure (fixed by the two-listener split)
+- [PR #3368](https://github.com/fission/fission/pull/3368) — initial HMAC wiring on `storagesvc`
+- [PR #3369](https://github.com/fission/fission/pull/3369) — extension to `fetcher`, `builder`, `executor`, `router-internal`

--- a/content/en/docs/installation/upgrade.md
+++ b/content/en/docs/installation/upgrade.md
@@ -33,6 +33,35 @@ helm upgrade --namespace $FISSION_NAMESPACE fission fission-charts/fission-all
 
 _See [configuration](#configuration) below._
 
+## Upgrade to 1.23.x release
+
+v1.23.0 enables HMAC-signed internal authentication between Fission control-plane services by default.
+This introduces two changes operators should plan for before upgrading.
+
+### Public router no longer serves `/fission-function/<ns>/<name>`
+
+The router now binds two listeners — a public one (port `8888`, unchanged for user `HTTPTrigger` traffic) and a new internal one (port `8889`, hosting `/fission-function/<ns>/<name>`).
+This closes [GHSA-3g33-6vg6-27m8](https://github.com/fission/fission/security/advisories/GHSA-3g33-6vg6-27m8): function-invocation routes are no longer reachable from the public listener.
+
+**Any external tooling that today curls `/fission-function/...` against the public router URL (typically through an Ingress) will get `404` after upgrade.**
+Audit before upgrading and migrate any such caller to use a proper `HTTPTrigger`, or route through the internal Service (in-cluster only).
+
+### KEDA message-queue triggers and the connector signing gap
+
+`internalAuth.enabled` defaults to `true` in v1.23.0.
+Upstream `fission/kafka-http-connector` (and the other Fission KEDA connector images) do not yet sign their `/fission-function/...` invocations, so KEDA-driven message-queue triggers will receive `401` from the new router internal listener.
+
+If your installation uses KEDA-backed `MessageQueueTrigger` resources, **set `internalAuth.enabled=false` at upgrade time** until signing-aware KEDA connector images ship:
+
+```sh
+helm upgrade --namespace $FISSION_NAMESPACE fission fission-charts/fission-all \
+  --set internalAuth.enabled=false
+```
+
+With `enabled=false`, every signer/verifier short-circuits to pass-through and the cluster falls back to `NetworkPolicy` + namespace isolation alone — matching pre-1.23 in-cluster behaviour.
+
+See [Internal Service Authentication](/docs/installation/internal-auth/) for the full toggle matrix, secret rotation, and longer-term mitigation.
+
 ## Upgrade to 1.15.x release from 1.14.x release
 
 With 1.15.x release, following changes are made:

--- a/content/en/docs/releases/v1.23.0.md
+++ b/content/en/docs/releases/v1.23.0.md
@@ -4,14 +4,25 @@ linkTitle: v1.23.0
 weight: 70
 ---
 
+## Upgrade Notes
+
+{{< notice warning >}}
+**Behavioral change:** the router public listener no longer serves `/fission-function/<ns>/<name>`. External tooling that today calls those paths through the public router URL (typically via Ingress) will receive **404** after upgrading. This closes [GHSA-3g33-6vg6-27m8](https://github.com/fission/fission/security/advisories/GHSA-3g33-6vg6-27m8).
+
+**KEDA users:** `internalAuth.enabled` now defaults to `true`. Upstream `fission/kafka-http-connector` images do not yet sign their requests, so KEDA-driven message-queue triggers will receive `401`. Set `--set internalAuth.enabled=false` at upgrade time if you depend on stock KEDA connector images.
+
+See the [Upgrade Guide](/docs/installation/upgrade/#upgrade-to-123x-release) and [Internal Service Authentication](/docs/installation/internal-auth/) for the full procedure.
+{{< /notice >}}
+
 ## Deprecations/Removals
 
 - We continue to support Kubernetes 1.28 and above (`kubeVersion: ">=1.28.0-0"` in the Helm chart). No change in supported Kubernetes versions from v1.22.0.
+- `/fission-function/<ns>/<name>` is removed from the **public** router listener (port `8888`) and now lives only on a new internal listener (port `8889`). See Upgrade Notes above.
 - The legacy bash-based integration test suite has been retired. All integration tests now run as Go test suites.
 
 ## Highlights
 
-- **Application-layer HMAC authentication** has been added across internal Fission services — StorageSvc `/v1/archive`, fetcher, builder, executor, and router-internal — so cross-service calls are authenticated even within the cluster.
+- **Application-layer HMAC authentication** has been added across internal Fission services — StorageSvc `/v1/archive`, fetcher, builder, executor, and router-internal — so cross-service calls are authenticated even within the cluster. Enabled by default via `internalAuth.enabled=true`; see [Internal Service Authentication](/docs/installation/internal-auth/) for configuration, the toggle matrix, and master-secret rotation.
 - **Per-service NetworkPolicies** now cover every Fission listener, restricting in-cluster traffic to the components that actually need it.
 - The **fission-fetcher ServiceAccount token** is no longer mounted into user function containers, removing an unnecessary credential from the function runtime.
 

--- a/content/en/docs/releases/v1.23.0.md
+++ b/content/en/docs/releases/v1.23.0.md
@@ -1,0 +1,81 @@
+---
+title: "v1.23.0"
+linkTitle: v1.23.0
+weight: 70
+---
+
+## Deprecations/Removals
+
+- We continue to support Kubernetes 1.28 and above (`kubeVersion: ">=1.28.0-0"` in the Helm chart). No change in supported Kubernetes versions from v1.22.0.
+- The legacy bash-based integration test suite has been retired. All integration tests now run as Go test suites.
+
+## Highlights
+
+- **Application-layer HMAC authentication** has been added across internal Fission services — StorageSvc `/v1/archive`, fetcher, builder, executor, and router-internal — so cross-service calls are authenticated even within the cluster.
+- **Per-service NetworkPolicies** now cover every Fission listener, restricting in-cluster traffic to the components that actually need it.
+- The **fission-fetcher ServiceAccount token** is no longer mounted into user function containers, removing an unnecessary credential from the function runtime.
+
+## Fixes
+
+- Multiple security sweeps refreshed Go dependencies and closed Dependabot CVEs, including docker/cli (3 CVEs), golang.org/x/image, go-git, and the keda/v2 module.
+- Bumped the Go toolchain to **1.26**, and refreshed workflow CLI tool versions (helm, kind, skaffold, cosign, golangci-lint).
+- Helm chart published as **1.23.0**, now versioned independently from the app version.
+- Allow `=` characters in ingress trigger parsing — previously rejected as malformed (thanks @immanuwell).
+- Internal refactors: switched to the `logr` interface across the codebase, replaced `hashicorp/go-multierror` with the stdlib `errors` package, optimized the throttler, reduced webhook code duplication, and improved abstractions in the `mqtrigger` package.
+
+## Changelog
+
+### What's Changed
+
+* Bump github.com/expr-lang/expr from 1.17.6 to 1.17.7 by @dependabot[bot] in https://github.com/fission/fission/pull/3295
+* Separate chart and app version by @sanketsudake in https://github.com/fission/fission/pull/3297
+* Bump github.com/kedacore/keda/v2 from 2.18.2 to 2.18.3 by @dependabot[bot] in https://github.com/fission/fission/pull/3299
+* Bump the github-actions group with 3 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3301
+* Couple of enhancements & library updates by @dependabot[bot] in https://github.com/fission/fission/pull/3303
+* Use errors instead of hashicorp/go-multierror package by @sanketsudake in https://github.com/fission/fission/pull/3304
+* Use modernizer and upgrade golangci-lint config by @sanketsudake in https://github.com/fission/fission/pull/3306
+* Bump anchore/sbom-action from 0.20.11 to 0.21.0 in the github-actions group by @dependabot[bot] in https://github.com/fission/fission/pull/3305
+* Optimize throttler and reduce webhook code duplication by @sanketsudake in https://github.com/fission/fission/pull/3307
+* Switch to logr interface across codebase by @sanketsudake in https://github.com/fission/fission/pull/3313
+* Add better abstractions for Subscribe in mqtrigger package by @sanketsudake in https://github.com/fission/fission/pull/3317
+* Add checks in specialize pod handler by @sanketsudake in https://github.com/fission/fission/pull/3318
+* Bump the github-actions group across 1 directory with 6 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3319
+* Bump the go-dependencies group across 1 directory with 4 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3316
+* Update keda image versions to latest by @sanketsudake in https://github.com/fission/fission/pull/3320
+* Upgrade go version 1.26 by @sanketsudake in https://github.com/fission/fission/pull/3326
+* Bump the github-actions group across 1 directory with 5 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3329
+* Fix atomic usage by @sanketsudake in https://github.com/fission/fission/pull/3348
+* Bump the github-actions group across 1 directory with 17 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3341
+* Add CLAUDE & AGENTS md by @sanketsudake in https://github.com/fission/fission/pull/3349
+* Deps/security sweep 2026 04 by @sanketsudake in https://github.com/fission/fission/pull/3350
+* Bump the github-actions group with 8 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3352
+* Bump the github-actions group with 2 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3354
+* Bump golang.org/x/image from 0.18.0 to 0.38.0 by @dependabot[bot] in https://github.com/fission/fission/pull/3342
+* Migrate bash integration tests to Go by @sanketsudake in https://github.com/fission/fission/pull/3356
+* Retire bash integration test suite (Phase 6 teardown) by @sanketsudake in https://github.com/fission/fission/pull/3357
+* Bump Go dependencies (security sweep, 2026-05) by @sanketsudake in https://github.com/fission/fission/pull/3358
+* Misc fixes by @sanketsudake in https://github.com/fission/fission/pull/3361
+* Bump docker/cli to v29.4.3 to close 3 Dependabot CVEs by @sanketsudake in https://github.com/fission/fission/pull/3362
+* Add debug-github-ci skill by @sanketsudake in https://github.com/fission/fission/pull/3363
+* Security fixes 2026 05 by @sanketsudake in https://github.com/fission/fission/pull/3364
+* Add per-service NetworkPolicies covering every Fission listener by @sanketsudake in https://github.com/fission/fission/pull/3365
+* Drop fission-fetcher SA token from function user containers by @sanketsudake in https://github.com/fission/fission/pull/3366
+* Add HMAC application-layer auth to StorageSvc /v1/archive by @sanketsudake in https://github.com/fission/fission/pull/3368
+* fix: allow equals in ingress trigger parsing by @immanuwell in https://github.com/fission/fission/pull/3370
+* Extend HMAC application-layer auth to fetcher, builder, executor, and router-internal by @sanketsudake in https://github.com/fission/fission/pull/3369
+* Bump the github-actions group with 2 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3360
+* Bump github.com/go-git/go-git/v5 from 5.18.0 to 5.19.0 by @dependabot[bot] in https://github.com/fission/fission/pull/3371
+* Go deps security sweep (2026-05b) + Go 1.26.3 + chart v1.23.0 by @sanketsudake in https://github.com/fission/fission/pull/3375
+* Refresh workflow CLI tool versions (helm, kind, skaffold, cosign, golangci-lint) by @sanketsudake in https://github.com/fission/fission/pull/3376
+
+### New Contributors
+
+* @immanuwell made their first contribution in https://github.com/fission/fission/pull/3370
+
+**Full Changelog**: https://github.com/fission/fission/compare/v1.22.0...v1.23.0
+
+## References
+
+- [Environments](/environments/)
+- [Custom Resource Definition Specification](https://doc.crds.dev/github.com/fission/fission)
+- [Releases](https://github.com/fission/fission/releases)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/fission/fission.io
 
-go 1.25.4
+go 1.26.3
 
 require (
-	github.com/google/docsy v0.13.0 // indirect
+	github.com/google/docsy v0.15.0 // indirect
 	github.com/google/docsy/dependencies v0.7.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.13.0 h1:Y1oy5SmQ0ikJJsvkuefEVZMj0MTXLmVfpXbt7Ytc7rc=
-github.com/google/docsy v0.13.0/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
+github.com/google/docsy v0.15.0 h1:MNJ1nrE2ZuweXlUNaegTo/UbSKZJu+WMczahfZaxosI=
+github.com/google/docsy v0.15.0/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
 github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
 github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,21 +5,21 @@ publish = "public"
 [context.production.environment]
 HUGO_ENABLEGITINFO = "true"
 HUGO_ENV = "production"
-HUGO_VERSION = "0.152.2"
-GO_VERSION = "1.25.5"
+HUGO_VERSION = "0.161.1"
+GO_VERSION = "1.26.3"
 
 [context.split1.environment]
 HUGO_ENV = "production"
-HUGO_VERSION = "0.152.2"
-GO_VERSION = "1.25.5"
+HUGO_VERSION = "0.161.1"
+GO_VERSION = "1.26.3"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.152.2"
-GO_VERSION = "1.25.5"
+HUGO_VERSION = "0.161.1"
+GO_VERSION = "1.26.3"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.152.2"
-GO_VERSION = "1.25.5"
+HUGO_VERSION = "0.161.1"
+GO_VERSION = "1.26.3"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,20 +5,20 @@ publish = "public"
 [context.production.environment]
 HUGO_ENABLEGITINFO = "true"
 HUGO_ENV = "production"
-HUGO_VERSION = "0.161.1"
+HUGO_VERSION = "0.157.0"
 GO_VERSION = "1.26.3"
 
 [context.split1.environment]
 HUGO_ENV = "production"
-HUGO_VERSION = "0.161.1"
+HUGO_VERSION = "0.157.0"
 GO_VERSION = "1.26.3"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.161.1"
+HUGO_VERSION = "0.157.0"
 GO_VERSION = "1.26.3"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.161.1"
+HUGO_VERSION = "0.157.0"
 GO_VERSION = "1.26.3"
 
 [context.next.environment]


### PR DESCRIPTION
## Summary

- Bump `release_version` to `v1.23.0` and `chart_version` to `1.23.0` in `config.toml`. Install/compatibility docs pick up the new values via the `release-version` and `chart-version` shortcodes.
- New release notes page at `content/en/docs/releases/v1.23.0.md` with the full `What's Changed` / `New Contributors` lists from the [v1.23.0 GitHub release](https://github.com/fission/fission/releases/tag/v1.23.0), plus highlights of the v1.23.0 security work (per-service NetworkPolicies, HMAC application-layer auth across internal services, fetcher SA token removed from user containers).
- Bump Hugo `0.152.2 → 0.161.1`, Go `1.25.5 → 1.26.3`, and Docsy `0.13.0 → 0.15.0`. Versions are synced across `go.mod`, every `[context.*]` in `netlify.toml`, and `go.sum`.
- Add a `CLAUDE.md` describing the Hugo+Docsy+Netlify setup and a repo-local skill (`.claude/skills/bumping-hugo-docsy-site/`) documenting the version-bump procedure — notably that `hugo mod get` must be used instead of `go mod tidy` (which silently strips theme requires).

## Test plan

- [x] `hugo --gc --quiet` builds clean locally with Hugo 0.161.1 and Docsy 0.15.0.
- [ ] Netlify deploy preview renders the new `/docs/releases/v1.23.0/` page.
- [ ] Netlify deploy preview shows install/compatibility docs picking up `v1.23.0` / `1.23.0` from the shortcodes.
- [ ] Spot-check landing page and docs nav with the bumped Hugo version (no template regressions from the Docsy bump).