### PR TITLE
Redesign top navbar: transparent over hero, solid on scroll

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -240,15 +240,67 @@ input[type="search"]::placeholder {
   margin: 20px auto;
 }
 
+// Top navbar — slimmer and cohesive with the hero.
+// Deep-purple bar (not a black slab) that flows into the hero, no seam line below.
 .td-navbar {
+	background: #2a1866 !important;
+	border-bottom: none !important;
+	min-height: 3.25rem !important;
+	padding-top: 0.4rem !important;
+	padding-bottom: 0.4rem !important;
+
+	.navbar-brand img {
+		height: 32px !important;
+	}
+
 	.nav-link {
 		font-weight: normal !important;
-		color: #f4f4f4 !important;
-		border-bottom: 1px solid transparent;
+		color: #e6e2f5 !important;
+		padding-top: 0.4rem;
+		padding-bottom: 0.4rem;
+		border-bottom: 2px solid transparent;
+		transition: color .15s ease, border-color .15s ease;
+
+		i {
+			opacity: .7;
+			margin-right: .4rem;
+			font-size: .9em;
+			transition: opacity .15s ease;
+		}
+
 		&:hover {
 			color: #fff !important;
-			border-bottom: 1px solid #E361FD;
+			border-bottom: 2px solid #E361FD;
+			i { opacity: 1; }
 		}
+
+		&.active {
+			color: #fff !important;
+			border-bottom: 2px solid #E361FD;
+			i { opacity: 1; }
+		}
+	}
+}
+
+// Homepage only: navbar floats transparent over the hero and turns solid on
+// scroll. Limited to >=992px, where the hero has enough top padding (130px) to
+// sit behind the fixed bar without the title being covered. Below that the
+// default solid bar above applies.
+@media (min-width: 992px) {
+	.td-navbar.td-navbar-home {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 1030;
+		background: transparent !important;
+		box-shadow: none !important;
+		transition: background-color .3s ease, box-shadow .3s ease;
+	}
+
+	.td-navbar.td-navbar-home.scrolled {
+		background: #2a1866 !important;
+		box-shadow: 0 2px 14px rgba(20, 8, 60, .35) !important;
 	}
 }
 

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -9,3 +9,14 @@ docsearch({
 });
 </script>
 {{ end }}
+
+{{/* Homepage: turn the transparent hero navbar solid once the user scrolls. */}}
+<script>
+(function () {
+  var nav = document.querySelector('.td-navbar-home');
+  if (!nav) return;
+  function onScroll() { nav.classList.toggle('scrolled', window.scrollY > 24); }
+  onScroll();
+  window.addEventListener('scroll', onScroll, { passive: true });
+})();
+</script>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -5,10 +5,11 @@
 {{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
 
 <nav class="td-navbar js-navbar-scroll
-            {{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
+            {{- if $cover }} td-navbar-cover {{- end }}
+            {{- if .IsHome }} td-navbar-home {{- end }}" data-bs-theme="dark">
 <div class="container-fluid flex-column flex-md-row">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
-	<img src="/images/fission-white-logo.png" height="40" class="d-inline-block align-top" alt="">
+	<img src="/images/fission-white-logo.png" height="32" class="d-inline-block align-top" alt="">
     <!-- {{- /**/ -}}
     <span class="navbar-brand__logo navbar-logo">
       {{- if ne .Site.Params.ui.navbar_logo false -}}


### PR DESCRIPTION
Reworks the site top bar, which sat as a tall near-black slab disconnected from the purple hero.

## Changes

- **Slimmer:** logo 40 → 32px, `min-height` 4rem → 3.25rem, tighter vertical padding (~72px → ~55px).
- **Cohesive color:** the bar is now deep purple `#2a1866` (matching the hero) instead of the dark Bootstrap-theme near-black, with the bottom-border seam removed.
- **Homepage (≥992px):** the navbar floats **transparent over the hero** so the artwork shows through, then turns **solid `#2a1866` with a soft shadow once you scroll** (fixed/sticky header). Inner pages and screens <992px keep the slim solid bar, so nothing is ever covered.
- **Refined links:** softer idle color, 2px magenta underline on hover **and** active, and the menu icons are dimmed so they read as accents and brighten on hover (icons retained per design review).

## Files

- `layouts/partials/navbar.html` — logo size; adds `td-navbar-home` class on the homepage.
- `assets/scss/_variables_project.scss` — slim solid bar (all pages) + homepage transparent/scrolled overlay rules.
- `layouts/partials/hooks/body-end.html` — tiny scroll listener that toggles `.scrolled` past 24px.

## Verification

- Production build (`hugo --minify --printPathWarnings --gc`, Hugo 0.157.0): clean.
- Checked live in-browser: at the top — `position: fixed`, transparent, no shadow; on scroll — `#2a1866` + shadow; docs pages — slim solid bar unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)