### PR TITLE
Fix navbar search showing only on docs/blog (top bar shifts between pages)

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,15 +1,3 @@
-{{ with .Site.Params.algolia_docsearch }}
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>
-<script type="text/javascript">
-docsearch({
-  container: '#docsearch',
-  appId: 'MSV5TDX060',
-  indexName: 'fission',
-  apiKey: '301e59c1356fb69977837ee36681babe',
-});
-</script>
-{{ end }}
-
 {{/*
   Search consistency fix. Docsy's algolia init loops over a fixed list of
   container ids (#docsearch-0, #docsearch-1) and DocSearch throws when one is
@@ -33,7 +21,9 @@ docsearch({
           apiKey: {{ .apiKey | jsonify }},
           indexName: {{ .indexName | jsonify }},
         });
-      } catch (e) { /* container not ready; ignore */ }
+      } catch (e) {
+        console.warn('DocSearch init failed for', el, e);
+      }
     });
   }
   if (document.readyState === 'loading') {

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -10,6 +10,41 @@ docsearch({
 </script>
 {{ end }}
 
+{{/*
+  Search consistency fix. Docsy's algolia init loops over a fixed list of
+  container ids (#docsearch-0, #docsearch-1) and DocSearch throws when one is
+  absent, aborting the loop. On pages without a sidebar (home, environments,
+  examples, support) only the navbar container exists, so it never initializes
+  and the search box appears only on docs/blog — shifting the top bar between
+  pages. This re-initializes any DocSearch container Docsy left empty so the
+  navbar search shows consistently everywhere.
+*/}}
+{{ with .Site.Params.search.algolia }}
+<script>
+(function () {
+  function initOrphanSearch() {
+    if (typeof docsearch === 'undefined') return;
+    document.querySelectorAll('.td-search--algolia').forEach(function (el) {
+      if (el.children.length) return; // already initialized by Docsy
+      try {
+        docsearch({
+          container: el,
+          appId: {{ .appId | jsonify }},
+          apiKey: {{ .apiKey | jsonify }},
+          indexName: {{ .indexName | jsonify }},
+        });
+      } catch (e) { /* container not ready; ignore */ }
+    });
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initOrphanSearch);
+  } else {
+    initOrphanSearch();
+  }
+})();
+</script>
+{{ end }}
+
 {{/* Homepage: turn the transparent hero navbar solid once the user scrolls. */}}
 <script>
 (function () {


### PR DESCRIPTION
## Problem

The navbar search box appeared only on **docs** and **blog** pages, not on home, environments, examples, or support. Navigating home ⇄ docs made the top bar visibly shift as the search box popped in and out.

## Root cause

Docsy's algolia init loops over a fixed list of container ids:

```js
const containers = ['#docsearch-0', '#docsearch-1'];
for (let c of containers) { docsearch({ container: c, ... }); }
```

`docsearch()` **throws** when a container element is missing, which aborts the loop. The navbar renders one container; the docs/blog left sidebar renders a second. So:

- **docs/blog** — both `#docsearch-0` and `#docsearch-1` exist → both init → navbar search shows.
- **home / environments / examples / support** — only the navbar container exists. The loop hits the missing `#docsearch-0` *first*, throws, and never reaches the navbar container → no search box.

(`sidebar_search_disable = true` already signals the intent is navbar-only search; the bug just kept it from showing on most pages.)

## Fix

A small guarded re-init in the `body-end` hook (which runs after the DocSearch library loads and after Docsy's loop) initializes any `.td-search--algolia` container Docsy left empty. Containers Docsy already initialized are skipped, so there's no double-init on docs/blog.

Result: the **Search ⌘K** button now shows consistently in the top-right on every page, so the top bar no longer changes on navigation.

### Why right-aligned (not centered)

Top-right is the conventional, expected location for site search; centering nav search is unusual and would itself look off. The actual problem was *inconsistency*, not position — making the button present everywhere is what stops the bar from "breaking."

## Verification

- Checked live in-browser: search button now present in the navbar on `/`, `/docs/`, `/blog/`, `/environments/`, `/support/` (previously absent on the non-docs pages).
- Production build (`hugo --minify --printPathWarnings --gc`, Hugo 0.157.0): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)