### PR TITLE
Doc changes v1.25.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -111,8 +111,8 @@ privacy_policy = ""
 # current release branch - could be rc
 release_branch = "main"
 # the main version. Never is rc.
-release_version = "v1.24.0"
-chart_version = "1.24.0"
+release_version = "v1.25.0"
+chart_version = "1.25.0"
 
 slackurl = "/slack"
 

--- a/content/en/docs/installation/upgrade.md
+++ b/content/en/docs/installation/upgrade.md
@@ -33,6 +33,13 @@ helm upgrade --namespace $FISSION_NAMESPACE fission fission-charts/fission-all
 
 _See [configuration](#configuration) below._
 
+## Upgrade to 1.25.x release
+
+v1.25.0 raises the minimum supported Kubernetes version to **1.32** and continues the security-hardening line.
+The HTTPTrigger path and the PodSpec capability set are now tighter at admission, and the HTTPTrigger / TimeTrigger / CanaryConfig admission webhooks are removed in favor of API-server CEL — invalid cron schedules, CORS origins, and ingress paths are now admitted and surfaced as `…=False` status conditions rather than rejected at creation.
+
+See the [v1.25.0 release notes](/docs/releases/v1.25.0/#upgrade-notes) for the full list of breaking changes and the action each one requires.
+
 ## Upgrade to 1.24.x release
 
 v1.24.0 is a security-hardening release.

--- a/content/en/docs/reference/crd-reference.md
+++ b/content/en/docs/reference/crd-reference.md
@@ -54,7 +54,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[ArchiveType](#archivetype)_ | Type defines how the package is specified: literal or URL.<br />Available value:<br /> - literal<br /> - url |  |  |
+| `type` _[ArchiveType](#archivetype)_ | Type defines how the package is specified: literal or URL.<br />Available value:<br /> - literal<br /> - url |  | Enum: [ literal url] <br /> |
 | `literal` _integer array_ | Literal contents of the package. Can be used for<br />encoding packages below TODO (256 KB?) size. |  |  |
 | `url` _string_ | URL references a package. |  |  |
 | `checksum` _[Checksum](#checksum)_ | Checksum ensures the integrity of packages<br />referenced by URL. Ignored for literals. |  |  |
@@ -99,6 +99,7 @@ _Appears in:_
 
 
 Builder is the setting for environment builder.
+Bounded podspec / container safety rules — see the matching Runtime block above.
 
 
 
@@ -224,7 +225,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `namespace` _string_ |  |  |  |
-| `name` _string_ |  |  |  |
+| `name` _string_ |  |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
 
 
 #### Environment
@@ -252,7 +253,8 @@ Environment is environment for building and running user functions.
 
 
 
-EnvironmentReference is a reference to an environment.
+EnvironmentReference is a reference to an environment. It is used by both
+FunctionSpec.Environment and PackageSpec.Environment.
 
 
 
@@ -263,7 +265,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `namespace` _string_ |  |  |  |
-| `name` _string_ |  |  |  |
+| `name` _string_ | Name of the referenced environment. Optional + omitempty: an unset<br />reference is omitted and its Pattern skipped (a container function has<br />no environment; a Package with an unset environment is admitted and<br />fails later with a clear builder error — the fission CLI still rejects<br />it). When set, it must be a DNS-1123 label. |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
 
 
 #### EnvironmentSpec
@@ -279,14 +281,14 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `version` _integer_ | Version is the Environment API version<br />Version "1" allows user to run code snippet in a file, and<br />it's supported by most of the environments except tensorflow-serving.<br />Version "2" supports downloading and compiling user function if source archive is not empty.<br />Version "3" is almost the same with v2, but you're able to control the size of pre-warm pool of the environment. |  |  |
+| `version` _integer_ | Version is the Environment API version<br />Version "1" allows user to run code snippet in a file, and<br />it's supported by most of the environments except tensorflow-serving.<br />Version "2" supports downloading and compiling user function if source archive is not empty.<br />Version "3" is almost the same with v2, but you're able to control the size of pre-warm pool of the environment. |  | Maximum: 3 <br />Minimum: 1 <br /> |
 | `runtime` _[Runtime](#runtime)_ | Runtime is configuration for running function, like container image etc. |  |  |
 | `builder` _[Builder](#builder)_ | (Optional) Builder is configuration for builder manager to launch environment builder to build source code into<br />deployable binary. |  |  |
-| `allowedFunctionsPerContainer` _[AllowedFunctionsPerContainer](#allowedfunctionspercontainer)_ | (Optional) defaults to 'single'. Fission workflow uses<br />'infinite' to load multiple functions in one function pod.<br />Available value:<br />- single<br />- infinite |  |  |
+| `allowedFunctionsPerContainer` _[AllowedFunctionsPerContainer](#allowedfunctionspercontainer)_ | (Optional) defaults to 'single'. Fission workflow uses<br />'infinite' to load multiple functions in one function pod.<br />Available value:<br />- single<br />- infinite |  | Enum: [single infinite] <br /> |
 | `allowAccessToExternalNetwork` _boolean_ | Istio default blocks all egress traffic for safety.<br />To enable accessibility of external network for builder/function pod, set to 'true'.<br />(Optional) defaults to 'false' |  |  |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ | The request and limit CPU/MEM resource setting for poolmanager to set up pods in the pre-warm pool.<br />(Optional) defaults to no limitation. |  |  |
-| `poolsize` _integer_ | The initial pool size for environment |  |  |
-| `terminationGracePeriod` _integer_ | The grace time for pod to perform connection draining before termination. The unit is in seconds.<br />(Optional) defaults to 360 seconds |  |  |
+| `poolsize` _integer_ | The initial pool size for environment |  | Minimum: 0 <br /> |
+| `terminationGracePeriod` _integer_ | The grace time for pod to perform connection draining before termination. The unit is in seconds.<br />(Optional) defaults to 360 seconds |  | Minimum: 0 <br /> |
 | `keeparchive` _boolean_ | KeepArchive is used by fetcher to determine if the extracted archive<br />or unarchived file should be placed, which is then used by specialize handler.<br />(This is mainly for the JVM environment because .jar is one kind of zip archive.) |  |  |
 | `imagepullsecret` _string_ | ImagePullSecret is the secret for Kubernetes to pull an image from a<br />private registry. |  |  |
 
@@ -428,7 +430,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[FunctionReferenceType](#functionreferencetype)_ | Type indicates whether this function reference is by name or selector. For now,<br />the only supported reference type is by "name".  Future reference types:<br />  * Function by label or annotation<br />  * Branch or tag of a versioned function<br />  * A "rolling upgrade" from one version of a function to another<br />Available value:<br />- name<br />- function-weights |  |  |
+| `type` _[FunctionReferenceType](#functionreferencetype)_ | Type indicates whether this function reference is by name or selector. For now,<br />the only supported reference type is by "name".  Future reference types:<br />  * Function by label or annotation<br />  * Branch or tag of a versioned function<br />  * A "rolling upgrade" from one version of a function to another<br />Available value:<br />- name<br />- function-weights |  | Enum: [name function-weights] <br /> |
 | `name` _string_ | Name of the function. |  |  |
 | `functionweights` _object (keys:string, values:integer)_ | Function Reference by weight. this map contains function name as key and its weight<br />as the value. This is for canary upgrade purpose. |  |  |
 
@@ -451,6 +453,13 @@ _Appears in:_
 
 
 FunctionSpec describes the contents of the function.
+Bounded podspec safety rules — CEL admission gate for the simple pod-level
+invariants. Per-container SecurityContext checks stay in the webhook
+(ValidatePodSpecSafety) because iterating containers exceeds the CEL cost
+budget; the rules here cover only the bounded, cheap cases. The has()
+guards on each scalar are required: PodSpec's bool/string fields are
+json:"...,omitempty" so a zero/empty value is OMITTED from the object,
+and CEL errors with "no such key" if the rule accesses an absent field.
 
 
 
@@ -550,12 +559,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `host` _string_ | Deprecated: the original idea of this field is not for setting Ingress.<br />Since we have IngressConfig now, remove Host after couple releases. |  |  |
+| `host` _string_ | Deprecated: the original idea of this field is not for setting Ingress.<br />Since we have IngressConfig now, remove Host after couple releases. |  | Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?$` <br /> |
 | `relativeurl` _string_ | RelativeURL is the exposed URL for external client to access a function with. |  |  |
 | `prefix` _string_ | Prefix with which functions are exposed.<br />NOTE: Prefix takes precedence over URL/RelativeURL.<br />Note that it does not treat slashes specially ("/foobar/" will be matched by<br />the prefix "/foobar"). |  |  |
 | `keepPrefix` _boolean_ | When function is exposed with Prefix based path,<br />keepPrefix decides whether to keep or trim prefix in URL while invoking function. |  |  |
-| `method` _string_ | Use Methods instead of Method. This field is going to be deprecated in a future release<br />HTTP method to access a function. |  |  |
-| `methods` _string array_ | HTTP methods to access a function |  |  |
+| `method` _string_ | Use Methods instead of Method. This field is going to be deprecated in a future release<br />HTTP method to access a function. |  | Enum: [ GET HEAD POST PUT PATCH DELETE CONNECT OPTIONS TRACE] <br /> |
+| `methods` _string array_ | HTTP methods to access a function |  | items:Enum: [GET HEAD POST PUT PATCH DELETE CONNECT OPTIONS TRACE] <br /> |
 | `functionref` _[FunctionReference](#functionreference)_ | FunctionReference is a reference to the target function. |  |  |
 | `createingress` _boolean_ | If CreateIngress is true, router will create an ingress definition. |  |  |
 | `ingressconfig` _[IngressConfig](#ingressconfig)_ | IngressConfig for router to set up Ingress. |  |  |
@@ -656,7 +665,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `namespace` _string_ |  |  |  |
+| `namespace` _string_ |  |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
 | `type` _string_ | Type of resource to watch (Pod, Service, etc.) |  |  |
 | `labelselector` _object (keys:string, values:string)_ | Resource labels |  |  |
 | `functionref` _[FunctionReference](#functionreference)_ | The reference to a function for kubewatcher to invoke with<br />when receiving events. |  |  |
@@ -796,7 +805,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `namespace` _string_ |  |  |  |
-| `name` _string_ |  |  |  |
+| `name` _string_ | The package reference is optional, so Name is omitempty: when unset it<br />is omitted from the object and the Pattern below is skipped (a function<br />may legitimately have no package). A present name must be a DNS-1123<br />label. A leaf Pattern (cheap structural validation) is used rather than<br />a spec-level CEL matches() (which would exceed the cost budget). |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
 | `resourceversion` _string_ | Including resource version in the reference forces the function to be updated on<br />package update, making it possible to cache the function based on its metadata. |  |  |
 
 
@@ -832,7 +841,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `buildstatus` _[BuildStatus](#buildstatus)_ | BuildStatus is the package build status. | pending |  |
+| `buildstatus` _[BuildStatus](#buildstatus)_ | BuildStatus is the package build status. | pending | Enum: [ pending running succeeded failed none] <br /> |
 | `buildlog` _string_ | BuildLog stores build log during the compilation. |  |  |
 | `lastUpdateTimestamp` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdateTimestamp will store the timestamp the package was last updated<br />metav1.Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.<br />https://github.com/kubernetes/apimachinery/blob/44bd77c24ef93cd3a5eb6fef64e514025d10d44e/pkg/apis/meta/v1/time.go#L26-L35 |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest observations of the package's state. |  |  |
@@ -845,6 +854,11 @@ _Appears in:_
 
 
 Runtime is the setting for environment runtime.
+Bounded podspec / container safety rules — CEL admission gate for the
+simple, bounded fields. Per-container PodSpec.containers iteration stays
+in the webhook (ValidatePodSpecSafety / ValidateContainerSafety) because
+it exceeds the CEL cost budget. The has() guards are required because
+json:"...,omitempty" omits zero/empty values from the object.
 
 
 
@@ -872,7 +886,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `namespace` _string_ |  |  |  |
-| `name` _string_ |  |  |  |
+| `name` _string_ |  |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
 
 
 #### StrategyType

--- a/content/en/docs/releases/v1.25.0.md
+++ b/content/en/docs/releases/v1.25.0.md
@@ -63,37 +63,56 @@ The Function, Environment, Package, MessageQueueTrigger, and KubernetesWatchTrig
 
 ## Highlights
 
-- **RFC-0005 — control-plane scalability, robustness & lifecycle.**
-  Router and executor (plus all singleton controllers — kubewatcher, timer, mqtrigger Kafka, mqt_keda, buildermgr, canaryconfigmgr) move onto **controller-runtime Reconcilers** with opt-in **leader election** (active-passive Lease), graceful drain on shutdown, `/readyz` gated on cache sync (and leadership where applicable), jittered retry + panic-recovery middleware on router transports, and the removal of `os.Exit(1)` from hot/reconcile paths.
-  A default single-replica install behaves identically — leader election reports leader immediately when disabled.
-- **CRD validation in the API server (CEL + SSA).**
-  Executor type/strategy enums, autoscale bounds, archive/checksum/build-status enums, environment version range, pool-size and termination-grace bounds, HTTPTrigger HTTP-method enums, FunctionReference name (DNS-1123) validation, and `Environment.spec.version` immutability are now enforced as `x-kubernetes-validations`.
-  GitOps tools (Argo CD, Flux) and `kubectl explain` see the rules; they apply even if the admission webhook is not running.
-- **Helm chart upgrades for HA.**
-  Templated replicas and opt-in `leaderElection.enabled` for every controller; probe split (`/readyz` readiness, `/healthz` liveness); opt-in rollout strategy and `terminationGracePeriodSeconds`; opt-in **PodDisruptionBudgets** for router and executor; opt-in **HorizontalPodAutoscaler** for the router; `coordination.k8s.io/leases` RBAC wired into every leader-electable role.
-- **Reliable cross-namespace function teardown.**
-  A new `fission.io/function-cleanup` finalizer on the shared Function reconciler tears workloads down via the owning executor type's `DeleteFunction` **before** the Function is collected, fixing the long-standing leak where owner-reference GC could not cross namespaces.
-  Gated by chart-wide `finalizerEnabled` (default **on**); turning it off drains any existing finalizers safely.
-- **Self-healing function workloads.**
-  The shared Function reconciler now `.Watches()` the Deployments and Services it manages — a backing Deployment deleted out-of-band re-enqueues the owning Function and is recreated proactively, instead of waiting for the next invocation.
-  Keeps `MinScale>0` functions warm; the request path remains the backstop.
-- **Memory and metrics.**
-  Latency summaries (`http_requests_duration_seconds` and friends) are now Prometheus histograms; the executor pod-cache maps are freed and the idle reaper's concurrency is bounded; the zap base logger is memoized and webhook loggers are lazy-init — composed with the aws-sdk-go drop, ~6 MB/process steady-state savings (pprof-confirmed).
+- **Reconciler consolidation in the executor ([RFC-0004](https://github.com/fission/fission/blob/main/rfc/0004-reconciler-consolidation.md), Implemented).**
+  The executor's nine controller-runtime reconcilers collapse to three.
+  A single Function-centric reconciler uses `.For(Function)` plus `.Watches(...)` to react to its real dependency graph — Environment, ConfigMap, Secret, and the Deployment/Service/HPA it manages — instead of three per-executor-type Function reconcilers, two Environment reconcilers, and two ConfigMap/Secret reconcilers each running their own predicates and goroutine pools.
+  The redundant standalone Deployment/Service informer factory is retired (one informer infrastructure removed from every executor process), and reads route through the manager cache.
+  No CRD, CLI, or Helm-value change.
+- **Self-healing function workloads ([RFC-0004](https://github.com/fission/fission/blob/main/rfc/0004-reconciler-consolidation.md)).**
+  Because owner-reference garbage collection cannot cross namespaces — and Fission's Deployment/Service/HPA often live in a `FunctionNamespace` distinct from the Function CR — the reconciler now `.Watches()` its managed objects via the existing function-identifying labels.
+  A Deployment deleted out-of-band re-enqueues the owning Function and is recreated proactively (targeting `MinScale`), so `MinScale>0` workloads stay warm instead of waiting for the next invocation.
+  The request-path heal (`GetFuncSvc → IsValid → re-specialize`) remains the backstop; the periodic reaper becomes a long-tail backstop rather than the primary repair path.
+- **Reliable cross-namespace function teardown ([RFC-0004](https://github.com/fission/fission/blob/main/rfc/0004-reconciler-consolidation.md)).**
+  A new `fission.io/function-cleanup` finalizer on the shared Function reconciler tears workloads down via the owning executor type's `DeleteFunction` **before** the Function CR is collected, closing the long-standing leak where the executor could miss a delete event and orphan cross-namespace workloads.
+  Gated by the chart-wide `finalizerEnabled` toggle (default **on**); flipping it off drains any existing finalizer safely, and the deletion teardown path is flag-independent so toggling never strands an object.
+- **CRD field rules now run in the API server ([RFC-0003](https://github.com/fission/fission/blob/main/rfc/0003-crd-modernization.md)).**
+  Validation that previously lived only in the admission webhook moves into `x-kubernetes-validations` (CEL) markers on the CRD types — executor type/strategy enums, autoscale bounds, archive/checksum/build-status enums, environment version range, pool-size and termination-grace bounds, HTTPTrigger HTTP-method enums, FunctionReference name (DNS-1123) validation, and `Environment.spec.version` immutability.
+  The same change adds Server-Side Apply list markers, so `kubectl apply --server-side`, Argo CD, and Flux merge Fission resources without clobbering peer entries.
+  Rules apply even when the admission webhook isn't running, and `kubectl explain` surfaces them.
+  The webhook is retained for the checks CEL cannot express (cross-namespace references, podspec/container security, the package archive literal-size limit) — see the related webhook removal under Deprecations.
+- **Control-plane robustness for HA installs.**
+  Router, executor, and the singleton controllers (kubewatcher, timer, mqtrigger Kafka, mqt_keda, buildermgr, canaryconfigmgr) gain graceful-drain on shutdown via a fresh `GRACEFUL_SHUTDOWN_TIMEOUT` context, opt-in active-passive leader election via Kubernetes `Lease` (only the leader runs mutating controllers/reapers; standbys keep warm caches), `/readyz` gated on informer-cache sync (and leadership where applicable) so non-leaders stay out of Service endpoints, jittered retry backoff plus panic-recovery middleware on both router listeners, and removal of `os.Exit(1)` from router/executor/KEDA-scaler hot paths (degrade-and-retry instead of crashloop).
+  Default single-replica installs behave identically — when `leaderElection.enabled: false`, the helper reports leader immediately.
+- **Helm chart additions for HA.**
+  Templated `replicas` and opt-in `leaderElection.enabled` for every leader-electable controller; probe split (`/readyz` readiness, `/healthz` liveness); opt-in rollout `strategy` and `terminationGracePeriodSeconds`; opt-in `podDisruptionBudget` for router and executor; opt-in `autoscaling` (HorizontalPodAutoscaler) for the router; `coordination.k8s.io/leases` RBAC wired into every leader-electable role.
+  All defaults preserve the prior 9-pod, single-replica topology.
+- **Memory and metrics wins.**
+  Latency summaries (`http_requests_duration_seconds` and friends) are converted to Prometheus histograms; executor pod-cache maps are freed and the idle reaper's concurrency is bounded; the zap base logger is memoized and webhook loggers are lazy-init.
+  Composed with the `aws-sdk-go` v1 / `graymeta/stow` drop in `pkg/storagesvc`, ~6 MB of always-resident heap is reclaimed in every `fission-bundle` subsystem (pprof-confirmed against the kind-CI run).
 
 ## Fixes
 
-- **HPA actually scales newdeploy/container functions.**
-  Pod-wide `Resource` CPU/memory metrics required every container in the pod to declare a request — Fission function pods rarely satisfied that, so KCM logged `missing request for cpu` and HPA scaling silently never worked.
-  The executor now rewrites those metrics to **`ContainerResource`** scoped to the function's main container (GA since Kubernetes 1.30), and reconciles drift on existing HPAs.
-- **Trigger event drops on router 404 are gone.**
-  `pkg/publisher` (kubewatcher / timer / mqtrigger) treated every 4xx from the router-internal listener as terminal, so events delivered during the window between trigger creation and mux reconciliation were silently dropped.
-  404 now falls through to the existing bounded retry (≈17 min worst case); other 4xx and 5xx semantics are unchanged.
-- **Zip-slip in archive extraction is closed.**
-  `pkg/utils` extraction and the fetcher/builder shared-volume FS operations are confined with `os.Root` (CWE-22).
-- **HTTPTrigger admission-webhook RBAC drift on AdoptExistingResources** — the executor now has `update` on services, and the adopt/cleanup path is hardened against concurrent re-stamping and deletion races.
-- **Native `sleep` preStop hook** replaces `exec /bin/sleep` in executor- and fetcher-managed pods, so preStop works on images without `/bin/sleep`.
-- **Routine churn no longer logs as errors** — pod/service deletion races during reconcile are tolerated quietly.
-- Routine security sweeps refreshed Go dependencies (Kubernetes 0.36, controller-runtime 0.24, KEDA 2.20, OTel, sarama, minio, x-image) and bumped kind k8s test images to v1.32.11 / v1.34.3 / v1.35.1.
+The five recurring runtime-error classes surfaced by CI log analysis are addressed under [RFC-0006 — Runtime Error-Noise Reduction & Pod-Lifecycle Correctness](https://github.com/fission/fission/blob/main/rfc/0006-runtime-error-noise-reduction.md) (Implemented in #3468–#3473):
+
+- **`exec /bin/sleep` preStop hooks are gone.**
+  The `lifecycle.preStop` hook on executor- and fetcher-managed pods used to invoke `/bin/sleep` via `exec`, which (a) fails on distroless images like `chainguard/static` that have no shell or `sleep`, (b) always exits 137 because the sleep runs the full grace window, and (c) is a wasted CRI round-trip at grace=0.
+  The hook now uses Kubernetes' native `lifecycle.preStop.sleep` action (GA since 1.30; our floor is 1.32) — the kubelet performs the sleep itself with no binary required, and grace=0 emits no hook at all.
+- **Trigger events on transient router 404s are no longer dropped.**
+  `pkg/publisher` (kubewatcher / timer / mqtrigger) treated every 4xx from the router's internal listener as terminal, so events delivered during the window between trigger creation and mux reconciliation were silently dropped.
+  404 now falls through to the existing bounded retry (10× / ~17 min worst case); other 4xx and 5xx semantics are unchanged.
+  CI now provisions metrics-server in the kind cluster so HPA scaling is actually exercised end-to-end for the first time.
+- **HPA actually scales newdeploy / container functions.**
+  Pod-wide `Resource` CPU/memory metrics require **every** container in the pod to declare a request, which Fission function pods rarely satisfy (function container has no CPU request unless the user or environment sets one, sidecars can lack them too).
+  KCM logged `missing request for cpu` and HPA scaling silently never worked.
+  The executor now rewrites those to **`ContainerResource`** metrics scoped to the function's main container (GA since Kubernetes 1.30) and reconciles drift on existing HPAs, both on create and on `fn update`.
+- **Deletion races no longer log as errors.**
+  Pool destroy on an already-deleted Deployment, `fsvc not found in cache` on function delete, `setInitialBuildStatus` on a deleted Package, and router tap of an expired fsvc are now NotFound-tolerant and stay out of the error log.
+- **Specialize-vs-delete race and finalizer write races closed** in the executor, and Function status writes retry on `Conflict` to absorb concurrent reconciles.
+- **Zip-slip in archive extraction is closed (CWE-22).**
+  `pkg/utils` zip extraction and the fetcher/builder shared-volume FS operations are confined with `os.Root` helpers.
+- **AdoptExistingResources hardened.**
+  The executor now has `update` on services in its RBAC, and the adopt/cleanup path is resilient to concurrent re-stamping with serial-adopt test coverage.
+- Routine security sweeps refreshed Go dependencies (Kubernetes 0.36, controller-runtime 0.24, KEDA 2.20, OTel, sarama, minio-go, x-image) and bumped integration-test kind images to v1.32.11 / v1.34.3 / v1.35.1.
 - Helm chart published as **1.25.0**, versioned independently from the app version.
 
 ## Changelog

--- a/content/en/docs/releases/v1.25.0.md
+++ b/content/en/docs/releases/v1.25.0.md
@@ -1,0 +1,179 @@
+---
+title: "v1.25.0"
+linkTitle: v1.25.0
+weight: 68
+---
+
+## Upgrade Notes
+
+{{< notice warning >}}
+v1.25.0 raises Fission's minimum Kubernetes version to **1.32**, tightens two more admission rules around the HTTPTrigger path and the PodSpec capability allowlist, and moves several validation checks from the admission webhook to API-server CEL.
+Specs that rely on the rejected primitives — or clusters older than 1.32 — will fail admission after upgrade.
+Audit the items below before rolling out.
+{{< /notice >}}
+
+For the general upgrade steps (CRDs, CLI, Helm chart), see the [Upgrade Guide](/docs/installation/upgrade/).
+The breaking changes specific to v1.25.0 and the action each requires are below.
+
+### Minimum Kubernetes is now 1.32
+
+The Helm chart's `kubeVersion` is `>=1.32.0-0`, the envtest harness pulls 1.32.x assets, and the runtime health-check floor (`MinimumKubernetesVersion`) is 1.32.
+Clusters older than 1.32 are no longer supported.
+
+As part of this, the fluentbit **PodSecurityPolicy** manifest and the `logger.podSecurityPolicy` Helm values are removed — PodSecurityPolicy was removed from Kubernetes in 1.25 and cannot exist on a 1.32+ cluster.
+If you relied on `logger.podSecurityPolicy`, use Pod Security Admission / Pod Security Standards instead.
+
+### HTTPTrigger path safety enforced at admission
+
+`HTTPTrigger.spec.relativeurl` / `spec.prefix` are now validated by both the API server (CEL) and the Go-side `Validate()` path that the CLI and router status conditions use.
+This closes [GHSA-vchh-r53j-8mpw](https://github.com/fission/fission/security/advisories/GHSA-vchh-r53j-8mpw): an HTTPTrigger written via `kubectl apply` or the Kubernetes REST API could previously specify an empty path, contain `..` traversal, be root-only (`/`), collide with router-owned routes (`/router-healthz`, `/readyz`, `/_version`, `/auth/login`), or shadow the router-internal `/fission-function/<ns>/<name>` prefix — the `fission` CLI already rejected these but `kubectl` bypassed them.
+
+A trigger that violates any of these now fails admission.
+The `fission` CLI is unchanged.
+If you had any such triggers in your specs, fix the paths before upgrading.
+
+### PodSpec capabilities are an allowlist (not a denylist)
+
+`Environment` and `Function` PodSpec admission and the merge-layer sanitizer switch from a six-entry denylist to an **allowlist** that matches Kubernetes Pod Security Admission's `restricted` profile: only `NET_BIND_SERVICE` may appear in `capabilities.add`.
+The merge layer also forces `capabilities.drop = ["ALL"]` on every container — including containers whose source had no `SecurityContext` at all — so the OCI runtime's default cap set (CHOWN/MKNOD/NET_RAW/SETUID/…) no longer reaches tenant containers.
+
+This closes [GHSA-qf5v-m7p4-95rp](https://github.com/fission/fission/security/advisories/GHSA-qf5v-m7p4-95rp): the previous denylist was structurally incomplete — `SYS_TIME` (corrupts the shared, non-namespaced node wall clock), `SYS_RAWIO`, `BPF`, `SYS_RESOURCE`, and `MAC_ADMIN` all passed through, and the OCI default `DAC_OVERRIDE` reached containers regardless.
+
+Any Environment/Function/Container spec that adds capabilities beyond `NET_BIND_SERVICE` is now rejected at admission.
+Tenants that silently relied on the OCI default cap set will also see those caps stripped at merge time.
+If a workload legitimately needed one of the dropped capabilities, run it outside Fission's tenant-facing CRDs.
+
+### HTTPTrigger / TimeTrigger / CanaryConfig admission webhooks are gone
+
+CRD field rules for these three resources now run as **CEL `x-kubernetes-validations`** in the API server itself.
+The dedicated admission webhooks are removed; the checks CEL cannot express (invalid cron schedules, CORS origin/`max-age`, ingress path regex) move into the **router** and **timer** reconcilers and surface as resource **status conditions** (`RouteAdmitted=False`, `Scheduled=False`) instead of admission rejections.
+
+Behavioral change: a raw `kubectl apply` / GitOps write of an invalid cron, CORS origin, or ingress path is now **admitted and flagged with a `…=False` condition** rather than rejected at creation.
+The `fission` CLI still rejects these client-side, so the common path is unchanged.
+Operators relying on admission rejection of a malformed cron/CORS/ingress should check the new resource conditions instead.
+
+The Function, Environment, Package, MessageQueueTrigger, and KubernetesWatchTrigger webhooks are retained — they enforce the checks CEL cannot express (cross-namespace references, PodSpec/container security, package archive size, message-queue type/topic validity).
+
+## Deprecations/Removals
+
+- Kubernetes **< 1.32 is no longer supported** (`kubeVersion: ">=1.32.0-0"` in the Helm chart).
+- `logger.podSecurityPolicy` Helm values and the fluentbit PodSecurityPolicy manifest are removed (PSP was removed in Kubernetes 1.25).
+- **Admission webhooks for HTTPTrigger, TimeTrigger, and CanaryConfig** are dropped — replaced by API-server CEL plus reconciler-written status conditions.
+- The `fission-bundle` binary no longer pulls in **`github.com/aws/aws-sdk-go` v1** or **`github.com/graymeta/stow`**: `pkg/storagesvc` now uses `minio-go/v7` directly. ~3 MB of always-resident heap per subsystem is reclaimed; behaviour and Package URL `?id=…` formats are preserved.
+
+## Highlights
+
+- **RFC-0005 — control-plane scalability, robustness & lifecycle.**
+  Router and executor (plus all singleton controllers — kubewatcher, timer, mqtrigger Kafka, mqt_keda, buildermgr, canaryconfigmgr) move onto **controller-runtime Reconcilers** with opt-in **leader election** (active-passive Lease), graceful drain on shutdown, `/readyz` gated on cache sync (and leadership where applicable), jittered retry + panic-recovery middleware on router transports, and the removal of `os.Exit(1)` from hot/reconcile paths.
+  A default single-replica install behaves identically — leader election reports leader immediately when disabled.
+- **CRD validation in the API server (CEL + SSA).**
+  Executor type/strategy enums, autoscale bounds, archive/checksum/build-status enums, environment version range, pool-size and termination-grace bounds, HTTPTrigger HTTP-method enums, FunctionReference name (DNS-1123) validation, and `Environment.spec.version` immutability are now enforced as `x-kubernetes-validations`.
+  GitOps tools (Argo CD, Flux) and `kubectl explain` see the rules; they apply even if the admission webhook is not running.
+- **Helm chart upgrades for HA.**
+  Templated replicas and opt-in `leaderElection.enabled` for every controller; probe split (`/readyz` readiness, `/healthz` liveness); opt-in rollout strategy and `terminationGracePeriodSeconds`; opt-in **PodDisruptionBudgets** for router and executor; opt-in **HorizontalPodAutoscaler** for the router; `coordination.k8s.io/leases` RBAC wired into every leader-electable role.
+- **Reliable cross-namespace function teardown.**
+  A new `fission.io/function-cleanup` finalizer on the shared Function reconciler tears workloads down via the owning executor type's `DeleteFunction` **before** the Function is collected, fixing the long-standing leak where owner-reference GC could not cross namespaces.
+  Gated by chart-wide `finalizerEnabled` (default **on**); turning it off drains any existing finalizers safely.
+- **Self-healing function workloads.**
+  The shared Function reconciler now `.Watches()` the Deployments and Services it manages — a backing Deployment deleted out-of-band re-enqueues the owning Function and is recreated proactively, instead of waiting for the next invocation.
+  Keeps `MinScale>0` functions warm; the request path remains the backstop.
+- **Memory and metrics.**
+  Latency summaries (`http_requests_duration_seconds` and friends) are now Prometheus histograms; the executor pod-cache maps are freed and the idle reaper's concurrency is bounded; the zap base logger is memoized and webhook loggers are lazy-init — composed with the aws-sdk-go drop, ~6 MB/process steady-state savings (pprof-confirmed).
+
+## Fixes
+
+- **HPA actually scales newdeploy/container functions.**
+  Pod-wide `Resource` CPU/memory metrics required every container in the pod to declare a request — Fission function pods rarely satisfied that, so KCM logged `missing request for cpu` and HPA scaling silently never worked.
+  The executor now rewrites those metrics to **`ContainerResource`** scoped to the function's main container (GA since Kubernetes 1.30), and reconciles drift on existing HPAs.
+- **Trigger event drops on router 404 are gone.**
+  `pkg/publisher` (kubewatcher / timer / mqtrigger) treated every 4xx from the router-internal listener as terminal, so events delivered during the window between trigger creation and mux reconciliation were silently dropped.
+  404 now falls through to the existing bounded retry (≈17 min worst case); other 4xx and 5xx semantics are unchanged.
+- **Zip-slip in archive extraction is closed.**
+  `pkg/utils` extraction and the fetcher/builder shared-volume FS operations are confined with `os.Root` (CWE-22).
+- **HTTPTrigger admission-webhook RBAC drift on AdoptExistingResources** — the executor now has `update` on services, and the adopt/cleanup path is hardened against concurrent re-stamping and deletion races.
+- **Native `sleep` preStop hook** replaces `exec /bin/sleep` in executor- and fetcher-managed pods, so preStop works on images without `/bin/sleep`.
+- **Routine churn no longer logs as errors** — pod/service deletion races during reconcile are tolerated quietly.
+- Routine security sweeps refreshed Go dependencies (Kubernetes 0.36, controller-runtime 0.24, KEDA 2.20, OTel, sarama, minio, x-image) and bumped kind k8s test images to v1.32.11 / v1.34.3 / v1.35.1.
+- Helm chart published as **1.25.0**, versioned independently from the app version.
+
+## Changelog
+
+### What's Changed
+
+* ci(security): tighten GITHUB_TOKEN permissions and pin dashboard-linter by @sanketsudake in https://github.com/fission/fission/pull/3407
+* chore(claude): add issue-pr-scrub backlog triage skill by @sanketsudake in https://github.com/fission/fission/pull/3408
+* fix(executor): stop updateCPUUtilizationSvc goroutine on pool destroy by @sanketsudake in https://github.com/fission/fission/pull/3410
+* fix(executor): apply executor-type label filter on informers (#2775) by @sanketsudake in https://github.com/fission/fission/pull/3411
+* perf(metrics): use a histogram for http_requests_duration_seconds by @sanketsudake in https://github.com/fission/fission/pull/3412
+* perf(executor): free pod cache maps and bound idle-reaper concurrency by @sanketsudake in https://github.com/fission/fission/pull/3413
+* perf(metrics): convert remaining latency summaries to histograms by @sanketsudake in https://github.com/fission/fission/pull/3414
+* feat(observability): memory-leak detection harness for router/executor by @sanketsudake in https://github.com/fission/fission/pull/3409
+* docs(skill): capture pprof profile analysis workflow in debug-github-ci by @sanketsudake in https://github.com/fission/fission/pull/3415
+* feat: RFC-0005 control-plane scalability, robustness & lifecycle by @sanketsudake in https://github.com/fission/fission/pull/3416
+* feat: RFC-0005 WS3 — buildermgr on controller-runtime Manager by @sanketsudake in https://github.com/fission/fission/pull/3417
+* feat: RFC-0005 WS3 — executor on controller-runtime Manager by @sanketsudake in https://github.com/fission/fission/pull/3418
+* feat: RFC-0005 WS3 — router on controller-runtime Manager by @sanketsudake in https://github.com/fission/fission/pull/3419
+* feat: RFC-0005 — native leader election for trigger subsystems; remove leaderelection helper by @sanketsudake in https://github.com/fission/fission/pull/3420
+* refactor: RFC-0005 — replace GroupManager with errgroup; remove pkg/utils/manager by @sanketsudake in https://github.com/fission/fission/pull/3421
+* feat: RFC-0005 WS3 — Reconciler scaffold + timer reconciler by @sanketsudake in https://github.com/fission/fission/pull/3422
+* feat: RFC-0005 WS3 — kubewatcher reconciler by @sanketsudake in https://github.com/fission/fission/pull/3423
+* refactor: RFC-0005 WS3 — canaryconfigmgr as a controller-runtime Reconciler by @sanketsudake in https://github.com/fission/fission/pull/3424
+* feat: RFC-0005 WS3 — mqtrigger as a controller-runtime Reconciler by @sanketsudake in https://github.com/fission/fission/pull/3425
+* feat: RFC-0005 WS3 (D1) — shared executor idle reaper by @sanketsudake in https://github.com/fission/fission/pull/3426
+* feat: RFC-0005 WS3 (B1) — Package /status subresource + split status writers by @sanketsudake in https://github.com/fission/fission/pull/3427
+* feat: RFC-0005 WS3 (B2) — buildermgr Environment + Package reconcilers by @sanketsudake in https://github.com/fission/fission/pull/3428
+* feat: RFC-0005 WS3 (C) — router HTTPTrigger + Function reconcilers by @sanketsudake in https://github.com/fission/fission/pull/3429
+* feat: RFC-0005 WS3 (D/cms) — executor ConfigMap/Secret reconcilers by @sanketsudake in https://github.com/fission/fission/pull/3430
+* feat: RFC-0005 WS3 (D/container) — container executor Function reconciler by @sanketsudake in https://github.com/fission/fission/pull/3431
+* feat: RFC-0005 WS3 (D/poolmgr) — pool manager Function reconciler by @sanketsudake in https://github.com/fission/fission/pull/3432
+* feat: RFC-0005 WS3 (D/newdeploy) — newdeploy Function + Environment reconcilers by @sanketsudake in https://github.com/fission/fission/pull/3433
+* feat: RFC-0005 WS3 (D/poolmgr-lifecycle) — poolmgr Environment + Function reconcilers by @sanketsudake in https://github.com/fission/fission/pull/3434
+* feat: RFC-0005 WS3 (D/poolmgr-rs) — poolmgr ReplicaSet reconciler by @sanketsudake in https://github.com/fission/fission/pull/3435
+* feat: RFC-0005 WS3 (D/poolmgr-readypod) — readyPod reconciler; retire gpmInformerFactory by @sanketsudake in https://github.com/fission/fission/pull/3436
+* ci: bump integration-test kind k8s versions to v1.32.11 / v1.34.3 / v1.35.1 by @sanketsudake in https://github.com/fission/fission/pull/3437
+* refactor: retire finformerFactory + fix TestGoEnv router resolver staleness by @sanketsudake in https://github.com/fission/fission/pull/3438
+* logger: migrate --logger pod watch to a controller-runtime reconciler by @sanketsudake in https://github.com/fission/fission/pull/3440
+* mqtrigger: migrate --mqt_keda scaler to a controller-runtime reconciler by @sanketsudake in https://github.com/fission/fission/pull/3439
+* test: deepen executor updateFunction + fission CLI integration coverage by @sanketsudake in https://github.com/fission/fission/pull/3441
+* perf(logger): memoize base zap logger and lazy-init webhook loggers by @sanketsudake in https://github.com/fission/fission/pull/3442
+* perf(storagesvc): replace graymeta/stow with minio-go + os to drop aws-sdk-go v1 by @sanketsudake in https://github.com/fission/fission/pull/3443
+* fix(utils): confine zip extraction with os.Root (zip-slip / CWE-22) by @sanketsudake in https://github.com/fission/fission/pull/3444
+* refactor(fetcher,builder): confine shared-volume FS ops with os.Root helpers by @sanketsudake in https://github.com/fission/fission/pull/3445
+* chore(utils): remove unused functions from pkg/utils by @sanketsudake in https://github.com/fission/fission/pull/3446
+* chore: raise minimum supported Kubernetes to 1.32 by @sanketsudake in https://github.com/fission/fission/pull/3448
+* fix(rbac): grant executor `update` on services for AdoptExistingResources + serial adopt coverage by @sanketsudake in https://github.com/fission/fission/pull/3447
+* fix(executor): make AdoptExistingResources resilient to concurrent re-stamping by @sanketsudake in https://github.com/fission/fission/pull/3450
+* feat(crd): validate CRDs in the API server with CEL + server-side-apply markers by @sanketsudake in https://github.com/fission/fission/pull/3449
+* refactor(executor): context-bound adopt/cleanup wait + de-duplicate adopt/cleanup by @sanketsudake in https://github.com/fission/fission/pull/3451
+* refactor(webhook): drop the HTTPTrigger, TimeTrigger and CanaryConfig admission webhooks by @sanketsudake in https://github.com/fission/fission/pull/3452
+* refactor(validation): split CRD validation into CEL-covered and webhook-only halves by @sanketsudake in https://github.com/fission/fission/pull/3454
+* refactor(executor): share deployment helpers across newdeploy/container + cleanup by @sanketsudake in https://github.com/fission/fission/pull/3453
+* test(fission-cli): raise coverage + dedupe create commands; fix canary status bug by @sanketsudake in https://github.com/fission/fission/pull/3455
+* Security dep sweep: k8s 0.36 / controller-runtime 0.24 / KEDA 2.20 + OTel/sarama/minio/x-image by @sanketsudake in https://github.com/fission/fission/pull/3456
+* refactor(executor): share one Environment reconciler across executor types by @sanketsudake in https://github.com/fission/fission/pull/3457
+* refactor(executor): share one Function reconciler across executor types by @sanketsudake in https://github.com/fission/fission/pull/3458
+* refactor(executor): serve newdeploy/container IsValid from the Manager cache (retire standalone informer factory) by @sanketsudake in https://github.com/fission/fission/pull/3459
+* feat(executor): opt-in cleanup finalizer for reliable cross-namespace teardown by @sanketsudake in https://github.com/fission/fission/pull/3460
+* feat(executor): self-heal newdeploy/container function workloads on drift by @sanketsudake in https://github.com/fission/fission/pull/3461
+* Bump the docker-images group across 5 directories with 1 update by @dependabot[bot] in https://github.com/fission/fission/pull/3311
+* chore(deps): bump the github-actions group with 3 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3463
+* chore(deps): bump github.com/prometheus/common from 0.68.0 to 0.68.1 in the go-dependencies group by @dependabot[bot] in https://github.com/fission/fission/pull/3462
+* fix(httptrigger): enforce path-safety at admission (GHSA-vchh) by @sanketsudake in https://github.com/fission/fission/pull/3464
+* fix(podspec): allowlist tenant caps + force drop:[ALL] (GHSA-qf5v) by @sanketsudake in https://github.com/fission/fission/pull/3465
+* chore: Go 1.26.4, kind v0.32.0, release version 1.25.0 by @sanketsudake in https://github.com/fission/fission/pull/3467
+* fix(executor,fetcher): use native sleep preStop hook instead of exec /bin/sleep by @sanketsudake in https://github.com/fission/fission/pull/3468
+* fix: tolerate deletion races and stop logging routine churn as errors by @sanketsudake in https://github.com/fission/fission/pull/3469
+* fix(publisher): retry transient router 404s; ci: metrics-server for HPA by @sanketsudake in https://github.com/fission/fission/pull/3470
+* fix(test): retry Function status writes on conflict by @sanketsudake in https://github.com/fission/fission/pull/3471
+* fix(executor): close specialize-vs-delete race; tolerate finalizer write races by @sanketsudake in https://github.com/fission/fission/pull/3472
+* fix(executor): scope HPA resource metrics to the function container by @sanketsudake in https://github.com/fission/fission/pull/3473
+* chore: sync generated code with types.go doc comments by @sanketsudake in https://github.com/fission/fission/pull/3474
+
+**Full Changelog**: https://github.com/fission/fission/compare/v1.24.0...v1.25.0
+
+## References
+
+- [Upgrade Guide](/docs/installation/upgrade/)
+- [Environments](/environments/)
+- [Custom Resource Definition Specification](https://doc.crds.dev/github.com/fission/fission)
+- [Releases](https://github.com/fission/fission/releases)


### PR DESCRIPTION
## Summary

- New release-notes page `content/en/docs/releases/v1.25.0.md` (weight 68) covering the v1.25.0 upgrade notes, deprecations, RFC-0005 control-plane HA highlights, CEL/SSA CRD validation, finalizer + drift self-heal, fixes, and the verbatim "What's Changed" changelog.
- Bumped `release_version` to `v1.25.0` and `chart_version` to `1.25.0` in `config.toml`.
- Added a compact v1.25.x section in `content/en/docs/installation/upgrade.md` that points at the release-notes Upgrade Notes for the per-release breaking-change detail.
- Refreshed `content/en/docs/reference/crd-reference.md` against the v1.25.0 CRDs (CEL `Enum:` / `Pattern:` / `Maximum:` / `Minimum:` markers, doc-comment updates for `EnvironmentReference`, `PackageReference`, the new bounded-podspec notes).

## Test plan

- [x] `./build.sh` (pinned Hugo 0.157.0 extended): `Pages: 303` — clean, no warnings.
- [x] Both upgrade anchors render: `upgrade-to-124x-release` and `upgrade-to-125x-release` resolve in `public/docs/installation/upgrade/index.html`.
- [x] `public/docs/releases/v1.25.0/index.html` renders the Upgrade Notes / Highlights / Fixes / Changelog sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)