### PR TITLE
SEO + LLM-friendliness: structured data, llms.txt, meta descriptions

### DIFF
--- a/.claude/resources/page-patterns.md
+++ b/.claude/resources/page-patterns.md
@@ -21,6 +21,7 @@ New top-level sections must slot into this learning path, not append at the end.
 **Never `{{< relref >}}`** on regular content pages — the custom shortcode only resolves section `_index.md` paths and fails the build otherwise.
 - Versions in prose: `{{< release-version >}}` / `{{< chart-version >}}` shortcodes, never literals (exceptions: historical rows in `installation/compatibility.md`, release-notes pages about themselves).
 - One sentence per line in Markdown (renders identically; diffs become per-sentence).
+- Every page needs a front-matter `description:` — see [seo.md](seo.md) for the SEO/LLM rules.
 - Auto-generated pages are off-limits to hand edits: `docs/reference/fission-cli/*`, `crd-reference.md`, `metrics-reference.md`.
 
 ## Catalog pages (environments, examples)

--- a/.claude/resources/seo.md
+++ b/.claude/resources/seo.md
@@ -1,0 +1,45 @@
+# SEO and LLM-friendliness conventions
+
+Established in the SEO/LLM audit round (June 2026).
+
+## Hard rules for every content page
+
+- **Front matter `description:` is required** — one factual sentence (~70–155 chars), task-oriented.
+It becomes the meta description, og:description, and the page's entry in `/llms.txt` and the markdown mirror.
+Pages without it fall back to `.Summary` (first ~70 words) — sloppy in SERPs and AI indexes.
+Only exception: auto-generated reference pages (`fission-cli/*`, `crd-reference.md`, `metrics-reference.md`).
+- **One `<h1>` per page.** Markdown pages get their h1 from the front-matter title — body headings start at `##`.
+HTML section pages (`_index.html` files) keep exactly one `<h1>` (the hero); later section headings are `<h2 class="section-title">` etc. — styling is class-based, so the tag level is free.
+- Release pages: `title: "vX.Y.Z Release Notes"` + `linkTitle: vX.Y.Z` (sidebar stays compact, `<title>`/h1 get keywords).
+
+## Structured data (JSON-LD)
+
+`layouts/partials/schema.html` — Docsy's head.html invokes `partial "schema.html"`, this site-level partial supplies it:
+
+| Page | Entities |
+|---|---|
+| Home | `Organization` + `WebSite` + `SoftwareApplication` (version from `params.release_version`) |
+| Blog post | `BlogPosting` (author Person, image from front-matter `images`, dates from `.Date`/`.Lastmod`) |
+| Docs page | `TechArticle` + `BreadcrumbList` (from `.Ancestors`) |
+
+Values go through `jsonify` — never hand-build JSON strings in the template.
+Validate after changes: extract `application/ld+json` blocks from built pages and `json.loads` them.
+
+## LLM outputs (config.toml)
+
+- `[outputs] home` includes `LLMS` → Docsy renders `/llms.txt` (markdown site index) from its `layouts/index.llms.txt`.
+- A `markdown` output format (text/markdown, baseName index, notAlternative) on home/section/page → Docsy's `layouts/all.md` renders every page as `<url>/index.md`, and llms.txt links those `.md` URLs automatically.
+- The `.md` mirrors stay out of `sitemap.xml` (verify with `grep -c '\.md' public/sitemap.xml` → 0).
+- AI crawlers (GPTBot, ClaudeBot, PerplexityBot, …) are deliberately NOT blocked in robots.txt.
+
+## Titles
+
+- Site title stays the short "Fission" (it suffixes every page title).
+- Home `<title>`/og:title come from the landing page's front-matter title ("Fission — Open Source Kubernetes-native Serverless Framework") via the **forked** `layouts/partials/head.html` (one-block change from Docsy v0.15 — re-diff on Docsy bumps).
+
+## Plumbing
+
+- `layouts/robots.txt` → `/robots.txt` with the `Sitemap:` line (`enableRobotsTXT = true`).
+- Canonicals: `layouts/partials/hooks/head-end.html` (per-page `canonicalUrl` front-matter override supported).
+- OG image: `static/images/og-image-fission.png` (1200×628) via `params.images`; blog posts override with front-matter `images`.
+- http→https and www→apex 301s are handled by Netlify; legacy URL redirects live in `netlify.toml` — add one whenever a page moves.

--- a/.claude/skills/writing-blog-posts/SKILL.md
+++ b/.claude/skills/writing-blog-posts/SKILL.md
@@ -32,6 +32,7 @@ images = ["images/featured/my-post-featured.png"]
 ```
 
 - `type = "blog"` is required.
+- `description` is required — it is the meta description, OG description, and llms.txt entry (see `.claude/resources/seo.md`).
 - `categories`: `["Tutorials"]` for how-tos, `["Fission"]` for project/release news — reuse existing categories, don't invent new ones.
 - `author` full name; it links to the author taxonomy page automatically.
 - Use a real current `date` with timezone — the list groups by year and sorts by it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ The details live in `.claude/resources/`:
 - [.claude/resources/mermaid-diagrams.md](.claude/resources/mermaid-diagrams.md) — diagram color kit, the <900px width rule, step-number style, lightbox/partial-cache gotchas.
 - [.claude/resources/page-patterns.md](.claude/resources/page-patterns.md) — docs nav order, page skeletons, catalog/blog/homepage/support page structures and their traps.
 - [.claude/resources/automation-ideas.md](.claude/resources/automation-ideas.md) — backlog of process automation worth building.
+- [.claude/resources/seo.md](.claude/resources/seo.md) — SEO/LLM rules: required front-matter descriptions, JSON-LD partial, llms.txt + markdown-mirror outputs, title/heading conventions.
 
 Consult the matching resource file before styling or restructuring a page.
 

--- a/config.toml
+++ b/config.toml
@@ -264,6 +264,25 @@ changefreq = "monthly"
 filename = "sitemap.xml"
 priority = 0.5
 
+# LLM-friendly outputs.
+# LLMS is defined by Docsy (text/plain, baseName "llms") and rendered by its
+# layouts/index.llms.txt -> serves /llms.txt, a markdown site index for AI agents.
+# The "markdown" format renders every page through Docsy's layouts/all.md ->
+# serves <page>/index.md, a plain-markdown mirror that llms.txt links to.
+[mediaTypes."text/markdown"]
+suffixes = ["md"]
+
+[outputFormats.markdown]
+mediaType = "text/markdown"
+baseName = "index"
+isPlainText = true
+notAlternative = true
+
+[outputs]
+home = ["HTML", "RSS", "LLMS", "markdown"]
+section = ["HTML", "markdown"]
+page = ["HTML", "markdown"]
+
 [params.search.algolia]
 appId = "MSV5TDX060"
 apiKey = "d814136dbb3b955516468a309c4b425e"

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -1,5 +1,5 @@
 ---
-title: "Fission"
+title: "Fission — Open Source Kubernetes-native Serverless Framework"
 linkTitle: "Fission"
 description: "Fast Opensource Kubernetes Serverless Framework"
 images: ["images/og-image-fission.png"]
@@ -401,7 +401,7 @@ images: ["images/og-image-fission.png"]
       <div class="col-lg-4">
         <br />
         <br />
-        <h1 class="section-title">Join the Community</h1>
+        <h2 class="section-title">Join the Community</h2>
         <br />
 
         <div class="show-mobile">

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -2,4 +2,5 @@
 title: "Fission Blog"
 linkTitle: "Blog"
 type: "blog"
+description: "Tutorials, release news, and engineering deep-dives on serverless on Kubernetes from the Fission team and community."
 ---

--- a/content/en/blog/falco_sidekick_fission.md
+++ b/content/en/blog/falco_sidekick_fission.md
@@ -3,6 +3,7 @@ title: "Kubernetes Response Engine: Falcosidekick + Fission"
 date: 2021-09-01
 author: Gaurav Gahlot
 categories: ["Tutorials"]
+description: "Build a Kubernetes response engine that uses Falco and Falcosidekick to trigger a Fission function which auto-deletes compromised pods."
 slug: falcosidekick-response-engine-fission
 ---
 

--- a/content/en/blog/fission-hello-world.md
+++ b/content/en/blog/fission-hello-world.md
@@ -3,6 +3,7 @@ title = "Hello World: Creating Functions using Fission (in Golang)"
 date = "2018-03-05T11:13:45-08:00"
 author = "Timirah James"
 categories = ["Tutorials"]
+description = "A beginner walkthrough for deploying a Go Hello World function on Fission, from Minikube and CLI setup to creating an environment and invoking the function."
 type = "blog"
 +++
 

--- a/content/en/blog/kafka_sasl_confluent.md
+++ b/content/en/blog/kafka_sasl_confluent.md
@@ -3,6 +3,7 @@ title: "Serverless Kafka Consumer for Confluent Cloud"
 date: 2021-11-10T11:21:01+05:30
 author: Ankit Chawla
 categories: ["Tutorials"]
+description: "Consume Apache Kafka topics from Confluent Cloud with Fission using the KEDA Kafka connector over SASL/SSL, with producer and consumer functions."
 draft: false
 ---
 

--- a/content/en/blog/serverless-nextjs-example-blog/index.md
+++ b/content/en/blog/serverless-nextjs-example-blog/index.md
@@ -3,6 +3,7 @@ title: "Serverless Next.js Example Blog with Fission"
 date: 2021-11-17T13:29:16+05:30
 author: Sanket Sudake
 categories: ["Tutorials"]
+description: "Deploy a Next.js blog on Fission using prefixed path routing so a single Node.js function serves all of the app's pages."
 draft: false
 ---
 

--- a/content/en/docs/releases/1.10.0.md
+++ b/content/en/docs/releases/1.10.0.md
@@ -1,8 +1,10 @@
 ---
-title: "1.10.0"
+title: "1.10.0 Release Notes"
 linkTitle: 1.10.0
 weight: 93
 draft: true
+description: >
+  Release notes for Fission 1.10.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/1.11.2.md
+++ b/content/en/docs/releases/1.11.2.md
@@ -1,8 +1,10 @@
 ---
-title: "1.11.2"
+title: "1.11.2 Release Notes"
 linkTitle: 1.11.2
 weight: 92
 draft: true
+description: >
+  Release notes for Fission 1.11.2 — highlights, fixes, and upgrade notes.
 ---
 
 Fission 1.11.2 is a release full of new things and we are super excited about it.

--- a/content/en/docs/releases/1.12.0.md
+++ b/content/en/docs/releases/1.12.0.md
@@ -1,8 +1,10 @@
 ---
-title: "1.12.0"
+title: "1.12.0 Release Notes"
 linkTitle: 1.12.0
 weight: 91
 draft: true
+description: >
+  Release notes for Fission 1.12.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/1.13.1.md
+++ b/content/en/docs/releases/1.13.1.md
@@ -1,8 +1,10 @@
 ---
-title: "1.13.1"
+title: "1.13.1 Release Notes"
 linkTitle: 1.13.1
 weight: 90
 draft: true
+description: >
+  Release notes for Fission 1.13.1 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/1.14.1.md
+++ b/content/en/docs/releases/1.14.1.md
@@ -1,8 +1,10 @@
 ---
-title: "1.14.1"
+title: "1.14.1 Release Notes"
 linkTitle: 1.14.1
 weight: 89
 draft: true
+description: >
+  Release notes for Fission 1.14.1 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/1.4.1.md
+++ b/content/en/docs/releases/1.4.1.md
@@ -1,8 +1,10 @@
 ---
-title: "1.4.1"
+title: "1.4.1 Release Notes"
 linkTitle: 1.4.1
 weight: 99
 draft: true
+description: >
+  Release notes for Fission 1.4.1 — highlights, fixes, and upgrade notes.
 ---
 
 ## Quick Highlight

--- a/content/en/docs/releases/1.5.0.md
+++ b/content/en/docs/releases/1.5.0.md
@@ -1,8 +1,10 @@
 ---
-title: "1.5.0"
+title: "1.5.0 Release Notes"
 linkTitle: 1.5.0
 weight: 98
 draft: true
+description: >
+  Release notes for Fission 1.5.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Quick Highlight

--- a/content/en/docs/releases/1.6.0.md
+++ b/content/en/docs/releases/1.6.0.md
@@ -1,8 +1,10 @@
 ---
-title: "1.6.0"
+title: "1.6.0 Release Notes"
 linkTitle: 1.6.0
 weight: 97 
 draft: true
+description: >
+  Release notes for Fission 1.6.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Quick Highlight

--- a/content/en/docs/releases/1.7.0.md
+++ b/content/en/docs/releases/1.7.0.md
@@ -1,8 +1,10 @@
 ---
-title: "1.7.0"
+title: "1.7.0 Release Notes"
 linkTitle: 1.7.0
 weight: 96 
 draft: true
+description: >
+  Release notes for Fission 1.7.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Critical Fix

--- a/content/en/docs/releases/1.8.0.md
+++ b/content/en/docs/releases/1.8.0.md
@@ -1,8 +1,10 @@
 ---
-title: "1.8.0"
+title: "1.8.0 Release Notes"
 linkTitle: 1.8.0
 weight: 95
 draft: true
+description: >
+  Release notes for Fission 1.8.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Bug fixes

--- a/content/en/docs/releases/1.9.0.md
+++ b/content/en/docs/releases/1.9.0.md
@@ -1,8 +1,10 @@
 ---
-title: "1.9.0"
+title: "1.9.0 Release Notes"
 linkTitle: 1.9.0
 weight: 94
 draft: true
+description: >
+  Release notes for Fission 1.9.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.15.0-rc1.md
+++ b/content/en/docs/releases/v1.15.0-rc1.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.15.0-rc1"
+title: "v1.15.0-rc1 Release Notes"
 linkTitle: v1.15.0-rc1
 weight: 88
+description: >
+  Release notes for Fission v1.15.0-rc1 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.15.0-rc2.md
+++ b/content/en/docs/releases/v1.15.0-rc2.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.15.0-rc2"
+title: "v1.15.0-rc2 Release Notes"
 linkTitle: v1.15.0-rc2
 weight: 87
+description: >
+  Release notes for Fission v1.15.0-rc2 — highlights, fixes, and upgrade notes.
 ---
 
 ## `fission-core` chart removed

--- a/content/en/docs/releases/v1.15.0.md
+++ b/content/en/docs/releases/v1.15.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.15.0"
+title: "v1.15.0 Release Notes"
 linkTitle: v1.15.0
 weight: 86
+description: >
+  Release notes for Fission v1.15.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Chart Restructure

--- a/content/en/docs/releases/v1.15.1.md
+++ b/content/en/docs/releases/v1.15.1.md
@@ -1,8 +1,10 @@
 ---
-title: "v1.15.1"
+title: "v1.15.1 Release Notes"
 linkTitle: v1.15.1
 weight: 85
 draft: true
+description: >
+  Release notes for Fission v1.15.1 — highlights, fixes, and upgrade notes.
 ---
 
 Please check the [1.15 release notes]({{< ref "v1.15.0.md" >}}) first before reading following notes.

--- a/content/en/docs/releases/v1.16.0-rc1.md
+++ b/content/en/docs/releases/v1.16.0-rc1.md
@@ -1,8 +1,10 @@
 ---
-title: "v1.16.0-rc1"
+title: "v1.16.0-rc1 Release Notes"
 linkTitle: v1.16.0-rc1
 weight: 84
 draft: true
+description: >
+  Release notes for Fission v1.16.0-rc1 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.16.0-rc2.md
+++ b/content/en/docs/releases/v1.16.0-rc2.md
@@ -1,8 +1,10 @@
 ---
-title: "v1.16.0-rc2"
+title: "v1.16.0-rc2 Release Notes"
 linkTitle: v1.16.0-rc2
 weight: 83
 draft: true
+description: >
+  Release notes for Fission v1.16.0-rc2 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.16.0.md
+++ b/content/en/docs/releases/v1.16.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.16.0"
+title: "v1.16.0 Release Notes"
 linkTitle: v1.16.0
 weight: 82
+description: >
+  Release notes for Fission v1.16.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.17.0.md
+++ b/content/en/docs/releases/v1.17.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.17.0"
+title: "v1.17.0 Release Notes"
 linkTitle: v1.17.0
 weight: 81
+description: >
+  Release notes for Fission v1.17.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.18.0.md
+++ b/content/en/docs/releases/v1.18.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.18.0"
+title: "v1.18.0 Release Notes"
 linkTitle: v1.18.0
 weight: 80
+description: >
+  Release notes for Fission v1.18.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.19.0.md
+++ b/content/en/docs/releases/v1.19.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.19.0"
+title: "v1.19.0 Release Notes"
 linkTitle: v1.19.0
 weight: 79
+description: >
+  Release notes for Fission v1.19.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.20.1.md
+++ b/content/en/docs/releases/v1.20.1.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.20.1"
+title: "v1.20.1 Release Notes"
 linkTitle: v1.20.1
 weight: 77
+description: >
+  Release notes for Fission v1.20.1 — highlights, fixes, and upgrade notes.
 ---
 
 If you are directly upgrading from release 1.17.0 or earlier, please do not skip intermediate release notes.

--- a/content/en/docs/releases/v1.20.2.md
+++ b/content/en/docs/releases/v1.20.2.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.20.2"
+title: "v1.20.2 Release Notes"
 linkTitle: v1.20.2
 weight: 76
+description: >
+  Release notes for Fission v1.20.2 — highlights, fixes, and upgrade notes.
 ---
 
 ## Features

--- a/content/en/docs/releases/v1.20.3.md
+++ b/content/en/docs/releases/v1.20.3.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.20.3"
+title: "v1.20.3 Release Notes"
 linkTitle: v1.20.3
 weight: 75
+description: >
+  Release notes for Fission v1.20.3 — highlights, fixes, and upgrade notes.
 ---
 
 {{< notice warning >}}

--- a/content/en/docs/releases/v1.20.4.md
+++ b/content/en/docs/releases/v1.20.4.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.20.4"
+title: "v1.20.4 Release Notes"
 linkTitle: v1.20.4
 weight: 74
+description: >
+  Release notes for Fission v1.20.4 — highlights, fixes, and upgrade notes.
 ---
 
 {{< notice warning >}}

--- a/content/en/docs/releases/v1.20.5.md
+++ b/content/en/docs/releases/v1.20.5.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.20.5"
+title: "v1.20.5 Release Notes"
 linkTitle: v1.20.5
 weight: 73
+description: >
+  Release notes for Fission v1.20.5 — highlights, fixes, and upgrade notes.
 ---
 
 {{< notice warning >}}

--- a/content/en/docs/releases/v1.21.0.md
+++ b/content/en/docs/releases/v1.21.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.21.0"
+title: "v1.21.0 Release Notes"
 linkTitle: v1.21.0
 weight: 72
+description: >
+  Release notes for Fission v1.21.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Deprecations/Removals

--- a/content/en/docs/releases/v1.22.0.md
+++ b/content/en/docs/releases/v1.22.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.22.0"
+title: "v1.22.0 Release Notes"
 linkTitle: v1.22.0
 weight: 71
+description: >
+  Release notes for Fission v1.22.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Deprecations/Removals

--- a/content/en/docs/releases/v1.23.0.md
+++ b/content/en/docs/releases/v1.23.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.23.0"
+title: "v1.23.0 Release Notes"
 linkTitle: v1.23.0
 weight: 70
+description: >
+  Release notes for Fission v1.23.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Upgrade Notes

--- a/content/en/docs/releases/v1.24.0.md
+++ b/content/en/docs/releases/v1.24.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.24.0"
+title: "v1.24.0 Release Notes"
 linkTitle: v1.24.0
 weight: 69
+description: >
+  Release notes for Fission v1.24.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Upgrade Notes

--- a/content/en/docs/releases/v1.25.0.md
+++ b/content/en/docs/releases/v1.25.0.md
@@ -1,7 +1,9 @@
 ---
-title: "v1.25.0"
+title: "v1.25.0 Release Notes"
 linkTitle: v1.25.0
 weight: 68
+description: >
+  Release notes for Fission v1.25.0 — highlights, fixes, and upgrade notes.
 ---
 
 ## Upgrade Notes

--- a/content/en/docs/usage/RBAC permissions/_index.md
+++ b/content/en/docs/usage/RBAC permissions/_index.md
@@ -3,6 +3,8 @@ title: "RBAC Permissions"
 linkTitle: RBAC permissions
 draft: false
 weight: 60
+description: >
+  Understand the Kubernetes RBAC roles Fission components use, the permissions needed to drive the CLI, and how to scope a user to one namespace.
 ---
 
 **This guide explains the Kubernetes RBAC that Fission's components use, the permissions a human (or CI) user needs to drive the Fission CLI, and how to scope a user down to a single namespace.**

--- a/content/en/docs/usage/function/access-secret-cfgmap-in-function.en.md
+++ b/content/en/docs/usage/function/access-secret-cfgmap-in-function.en.md
@@ -2,6 +2,8 @@
 title: "Accessing Secrets/ConfigMaps"
 draft: false
 weight: 4
+description: >
+  Mount Kubernetes Secrets and ConfigMaps into a Fission function and read their values for API keys and configuration.
 ---
 
 Functions can access Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) and [ConfigMaps](https://kubernetes.io/docs/concepts/storage/volumes/#configmap).

--- a/content/en/docs/usage/function/accessing-url-params.md
+++ b/content/en/docs/usage/function/accessing-url-params.md
@@ -2,6 +2,8 @@
 title: "Accessing URL parameters"
 date: 2018-10-25T17:39:41+08:00
 weight: 3
+description: >
+  Define path parameters in an HTTP trigger URL with gorilla/mux patterns and read their values inside a function via request headers.
 ---
 
 To develop an application consists with REST APIs, we may want to access URL parameters in functions.

--- a/content/en/docs/usage/function/canary-deployments.md
+++ b/content/en/docs/usage/function/canary-deployments.md
@@ -2,6 +2,8 @@
 title: "Canary Deployments for Functions"
 draft: false
 weight: 49
+description: >
+  Gradually shift HTTP traffic to a new function version with a CanaryConfig, using Prometheus health checks to auto-rollback on failure.
 ---
 
 This tutorial walks you through setting up a canary config to roll out a new version of a function with minimal risk.

--- a/content/en/docs/usage/function/container-functions.md
+++ b/content/en/docs/usage/function/container-functions.md
@@ -2,6 +2,8 @@
 title: "Running container as functions"
 draft: false
 weight: 46
+description: >
+  Run an existing container image as a function with the container executor via fission function run-container, without an environment or builder.
 ---
 
 {{% notice info %}}

--- a/content/en/docs/usage/function/enabling-istio-on-fission.md
+++ b/content/en/docs/usage/function/enabling-istio-on-fission.md
@@ -2,6 +2,8 @@
 title: "Enabling Istio on Fission"
 draft: false
 weight: 62
+description: >
+  Install Fission with the Istio service mesh and enable automatic sidecar injection for Fission and function pods.
 ---
 
 This tutorial sets up Fission with [Istio](https://istio.io/), a service mesh for Kubernetes.

--- a/content/en/docs/usage/function/environments.en.md
+++ b/content/en/docs/usage/function/environments.en.md
@@ -2,6 +2,8 @@
 title: "Create Environment"
 draft: false
 weight: 1
+description: >
+  Create a language runtime environment with fission env create, set CPU/memory limits and poolsize, and attach a builder image for source builds.
 ---
 
 An **environment** is the language runtime that executes your function code.

--- a/content/en/docs/usage/function/executor.en.md
+++ b/content/en/docs/usage/function/executor.en.md
@@ -2,6 +2,8 @@
 title: "Controlling Function Execution"
 draft: false
 weight: 45
+description: >
+  Choose and configure a function executor (poolmgr, newdeploy, or container) with --executortype to control cold starts and per-function autoscaling.
 ---
 
 This guide shows how to choose and configure an executor when you create a function.

--- a/content/en/docs/usage/function/functions.en.md
+++ b/content/en/docs/usage/function/functions.en.md
@@ -2,6 +2,8 @@
 title: "Create Function"
 draft: false
 weight: 2
+description: >
+  Create a function with fission fn create, route HTTP traffic to it, test it, and update its code through the everyday function workflow.
 ---
 
 This page walks you through the everyday function workflow: create a function, route HTTP traffic to it, test it, update its code, and inspect it.

--- a/content/en/docs/usage/function/package.en.md
+++ b/content/en/docs/usage/function/package.en.md
@@ -2,6 +2,8 @@
 title: "Packaging source code"
 draft: false
 weight: 35
+description: >
+  Create source and deployment packages with fission package, build source archives on the cluster with a builder, and attach packages to functions.
 ---
 
 A Fission **package** is the deployable artifact behind a function: it holds your code as either a *source archive* (built on the cluster by a builder) or a pre-built *deployment archive*.

--- a/content/en/docs/usage/function/private-registry.md
+++ b/content/en/docs/usage/function/private-registry.md
@@ -1,6 +1,8 @@
 ---
 title: "Pull an Image From a Private Registry"
 weight: 6
+description: >
+  Pull environment images from a private registry by passing an imagePullSecret to fission environment create with --imagepullsecret.
 ---
 
 With 1.7.0+, you can specify which credential to use for kubelet to pull images from the private registry.

--- a/content/en/docs/usage/function/url-as-archive-source.md
+++ b/content/en/docs/usage/function/url-as-archive-source.md
@@ -1,6 +1,8 @@
 ---
 title: "Use URL as archive source when creating functions/packages"
 weight: 7
+description: >
+  Embed a remote URL directly in a package archive when creating functions or packages to cut creation time and improve spec portability.
 ---
 
 Previously, the CLI tends to download the file and upload it to internal storagsvc to persist when a  user provides URL as archive source while creating the package.

--- a/content/en/docs/usage/ingress/_index.md
+++ b/content/en/docs/usage/ingress/_index.md
@@ -3,6 +3,8 @@ title: "Exposing Functions With Ingress"
 linkTitle: Ingress
 draft: false
 weight: 60
+description: >
+  Expose a Fission function outside the cluster on an FQDN using an NGINX ingress controller and Fission's route with --createingress.
 ---
 
 Ingress is a Kubernetes built-in resource that allows accessing Kubernetes services from outside of cluster with help of a ingress controller.

--- a/content/en/docs/usage/ingress/ingress-extra-settings.md
+++ b/content/en/docs/usage/ingress/ingress-extra-settings.md
@@ -1,6 +1,8 @@
 ---
 title: "Host, Path, Annotations and TLS"
 weight: 2
+description: >
+  Configure ingress host rules, paths, annotations, and TLS on a Fission route using --ingressrule, --ingressannotation, and --ingresstls.
 ---
 
 ### Annotations (`--ingressannotation`)

--- a/content/en/docs/usage/observability/linkerd.md
+++ b/content/en/docs/usage/observability/linkerd.md
@@ -1,6 +1,8 @@
 ---
 title: "Observability with Linkerd"
 weight: 20
+description: >
+  Mesh Fission function and component pods with the Linkerd service mesh to view request rate, success rate, and latency in its dashboard.
 ---
 
 ## Observability with Linkerd

--- a/content/en/docs/usage/observability/loki.md
+++ b/content/en/docs/usage/observability/loki.md
@@ -1,6 +1,8 @@
 ---
 title: "Logs with Loki"
 weight: 20
+description: >
+  Aggregate Fission component and function pod logs with the Grafana Loki, Promtail, and Grafana stack installed via Helm.
 ---
 
 ## Logs in Fission

--- a/content/en/docs/usage/observability/opentelemetry.md
+++ b/content/en/docs/usage/observability/opentelemetry.md
@@ -1,6 +1,8 @@
 ---
 title: "Tracing with OpenTelemetry"
 weight: 11
+description: >
+  Configure Fission's OpenTelemetry tracing via the Helm openTelemetry values to export OTLP spans to Jaeger or any compatible backend.
 ---
 
 ## Tracing in Fission

--- a/content/en/docs/usage/observability/prometheus.md
+++ b/content/en/docs/usage/observability/prometheus.md
@@ -1,6 +1,8 @@
 ---
 title: "Metrics with Prometheus"
 weight: 10
+description: >
+  Scrape Fission component and function metrics with Prometheus and visualize them in Grafana using the kube-prometheus-stack Helm chart.
 ---
 
 ## Metrics in Fission

--- a/content/en/docs/usage/spec/podspec/_index.md
+++ b/content/en/docs/usage/spec/podspec/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Add PodSpec to spec file"
 date: 2019-12-06T13:39:39+08:00
+description: >
+  Customize the Kubernetes PodSpec of Fission function and environment pods to control containers, volumes, scheduling, and security context.
 ---
 
 ## What is PodSpec

--- a/content/en/docs/usage/spec/podspec/containers.md
+++ b/content/en/docs/usage/spec/podspec/containers.md
@@ -1,6 +1,8 @@
 ---
 title: "Sidecar and Init Container"
 date: 2019-12-06T16:52:08+08:00
+description: >
+  Add init containers and sidecar containers to a Fission environment's PodSpec to run setup or auxiliary processes alongside functions.
 ---
 
 ## Init container

--- a/content/en/docs/usage/spec/podspec/envvar.md
+++ b/content/en/docs/usage/spec/podspec/envvar.md
@@ -1,6 +1,8 @@
 ---
 title: "Environment Variable"
 date: 2019-12-06T17:02:55+08:00
+description: >
+  Set environment variables on Fission environment pods via PodSpec, including exposing Kubernetes Secrets and ConfigMaps to your function.
 ---
 
 Functions sometimes require to pass-in parameter through environment variable to control internal behavior of a function like `GOMAXPROCS` for Go or you may want to expose secret/configmap as environment variable.

--- a/content/en/docs/usage/spec/podspec/toleration.md
+++ b/content/en/docs/usage/spec/podspec/toleration.md
@@ -1,6 +1,8 @@
 ---
 title: "Toleration"
 date: 2019-12-06T16:48:14+08:00
+description: >
+  Add tolerations to a Fission environment's PodSpec so functions schedule onto tainted nodes reserved for specific hardware or workloads.
 ---
 
 **Taints and tolerations** are mechanisms to influence scheduling of pods in Kubernetes.

--- a/content/en/docs/usage/spec/podspec/volume.md
+++ b/content/en/docs/usage/spec/podspec/volume.md
@@ -1,6 +1,8 @@
 ---
 title: "Volume"
 date: 2019-12-06T16:50:52+08:00
+description: >
+  Define and mount Kubernetes volumes on Fission function containers through PodSpec so stateful functions can access attached data.
 ---
 
 Functions are great for stateless things but there are use cases where functions deal with data, that is best attached as volume.

--- a/content/en/docs/usage/triggers/http-trigger.md
+++ b/content/en/docs/usage/triggers/http-trigger.md
@@ -2,6 +2,8 @@
 title: "HTTP Trigger"
 date: 2019-12-17T14:38:00+08:00
 weight: 1
+description: >
+  Invoke functions over HTTP by mapping URL paths and methods to functions with fission httptrigger create, including URL path parameters.
 ---
 
 An **HTTP trigger invokes a function when the router receives a matching HTTP request**.

--- a/content/en/docs/usage/triggers/kubewatcher.md
+++ b/content/en/docs/usage/triggers/kubewatcher.md
@@ -2,6 +2,8 @@
 title: "Kubernetes Watch Triggers"
 date: 2019-12-17T14:38:40+08:00
 weight: 5
+description: >
+  Invoke a function whenever a watched Kubernetes object is added, modified, or deleted using a kubewatcher-backed watch trigger.
 ---
 
 A **Kubernetes watch trigger invokes a function whenever a watched Kubernetes object changes** (added, modified, or deleted).

--- a/content/en/docs/usage/triggers/message-queue-trigger/_index.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger/_index.md
@@ -3,6 +3,8 @@ title: "[Removed] Message Queue Trigger: Kind Fission"
 date: 2019-12-17T14:38:11+08:00
 weight: 4
 draft: true
+description: >
+  Legacy reference for the removed Fission-kind message queue trigger that invoked functions from queue messages; use the KEDA trigger instead.
 ---
 
 {{% notice warning %}}

--- a/content/en/docs/usage/triggers/message-queue-trigger/nats-streaming.md
+++ b/content/en/docs/usage/triggers/message-queue-trigger/nats-streaming.md
@@ -2,6 +2,8 @@
 title: "Fission NATS Streaming"
 weight: 2
 draft: true
+description: >
+  Legacy reference for the removed Fission-kind NATS Streaming message queue trigger; use the KEDA-based NATS Streaming trigger instead.
 ---
 
 {{% notice warning %}}

--- a/content/en/docs/usage/triggers/timer.md
+++ b/content/en/docs/usage/triggers/timer.md
@@ -2,6 +2,8 @@
 title: "Timer Triggers"
 date: 2019-12-17T14:38:24+08:00
 weight: 4
+description: >
+  Invoke functions on a cron schedule with timer triggers using fission timer create, supporting cron specs and descriptors like @every.
 ---
 
 A **time trigger invokes a function on a cron schedule** — once, or repeatedly.

--- a/content/en/support/_index.html
+++ b/content/en/support/_index.html
@@ -76,7 +76,7 @@ images: ["images/og-image-fission.png"]
 <div class="container support-community">
   <div class="row align-items-center">
     <div class="col-lg-4 mb-4 mb-lg-0">
-      <h1 class="section-title support-community__title">Join the Community</h1>
+      <h2 class="section-title support-community__title">Join the Community</h2>
       <p class="section-text">Fission is built in the open — come say hi.</p>
     </div>
     <div class="col-lg-8">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,106 @@
+{{/* FORKED from Docsy v0.15.0 layouts/_partials/head.html.
+     Single change: the home page <title> uses the landing page's front-matter
+     title (descriptive, keyword-bearing) instead of the bare site title.
+     Re-diff against upstream when bumping Docsy. */ -}}
+{{/* cSpell:ignore docsearch opengraph outputformat */ -}}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+{{ $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+{{ if $darkMode.enable -}}
+{{/* Browser hints before CSS loads */ -}}
+<meta name="color-scheme" content="light dark">
+<meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
+<meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#000000">
+
+{{/* Styles to set canvas colors and avoid transitions */ -}}
+<style>
+  {{/* Set system colors as default */ -}}
+  html { background: Canvas; color: CanvasText; }
+  {{/* Define reasonable dark defaults */ -}}
+  @media (prefers-color-scheme: dark) {
+    html { background: #0b0d12; color: #e6e6e6; }
+  }
+  {{/* Avoid transitions until theme CSS is loaded */ -}}
+  html[data-theme-init] * { transition: none !important; }
+</style>
+
+{{/* Set theme attribute before CSS loads to prevent flash */ -}}
+<script>
+  (function() {
+    const themeKey = 'td-color-theme';
+    const storedTheme = localStorage.getItem(themeKey);
+    let theme = storedTheme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+    if (theme === 'auto') {
+      theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    document.documentElement.setAttribute('data-bs-theme', theme);
+  })();
+</script>
+{{ end -}}
+
+{{ range .AlternativeOutputFormats -}}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
+
+{{ $outputFormat := partial "outputformat.html" . -}}
+{{ if and hugo.IsProduction (ne $outputFormat "print") (ne .Site.Language.Lang "xx") -}}
+<meta name="robots" content="index, follow">
+{{ else -}}
+<meta name="robots" content="noindex, nofollow">
+{{ end -}}
+
+{{ partialCached "favicons.html" . }}
+<title>
+  {{- if .IsHome -}}
+    {{ .Title | default .Site.Title -}}
+  {{ else -}}
+    {{ with .Title }}{{ . }} | {{ end -}}
+    {{ .Site.Title -}}
+  {{ end -}}
+</title>
+<meta name="description" content="{{ partial "page-description.html" . }}">
+{{ partial "opengraph.html" . -}}
+{{ partial "schema.html" . -}}
+{{ partial "twitter_cards.html" . -}}
+{{ partialCached "head-css.html" . "head-css-cache-key" -}}
+<script
+  src="https://code.jquery.com/jquery-3.7.1.min.js"
+  integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
+  crossorigin="anonymous"></script>
+{{ if .Site.Params.offlineSearch -}}
+<script defer
+  src="https://unpkg.com/lunr@2.3.9/lunr.min.js"
+  integrity="sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli"
+  crossorigin="anonymous"></script>
+{{ end -}}
+
+{{ if .Site.Params.prism_syntax_highlighting -}}
+<link rel="stylesheet" href="{{ "css/prism.css" | relURL }}"/>
+{{ end -}}
+
+{{ template "algolia/head" . -}}
+
+{{ partial "hooks/head-end.html" . -}}
+
+{{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
+{{ if hugo.IsProduction -}}
+  {{ partial "google_analytics.html" . -}}
+{{ end -}}
+
+{{ define "algolia/head" -}}
+
+{{ if and .Site.Params.search (isset .Site.Params.search "algolia") -}}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.8.2"
+  integrity="sha512-l7pkV1dOURFyHCeH8I4fK9lCkQKuqhlsTCqRl3zktifDlB8oTUJ+mJPgYkK9kHpUut8j1iPquTv32t6hvTPv3g=="
+  crossorigin="anonymous" />
+{{ end -}}
+
+{{ if ne .Site.Params.algolia_docsearch nil -}}
+{{ warnf `Config 'params.algolia_docsearch' is deprecated: use 'params.search.algolia'
+      For details, see https://www.docsy.dev/docs/content/search/#algolia-docsearch.` -}}
+{{ end -}}
+
+{{ end -}}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,0 +1,101 @@
+{{- /*
+  JSON-LD structured data. Docsy's head.html invokes `partial "schema.html"`,
+  so this site-level partial is picked up on every page.
+  Entities: home = Organization + WebSite + SoftwareApplication;
+  blog posts = BlogPosting; docs pages = TechArticle + BreadcrumbList.
+*/ -}}
+{{- $org := dict
+  "@type" "Organization"
+  "name" "Fission"
+  "url" site.BaseURL
+  "logo" (absURL "images/logo.png")
+  "sameAs" (slice
+    "https://github.com/fission/fission"
+    "https://twitter.com/fissionio"
+    "https://fission.io/slack")
+-}}
+{{- $defaultImage := absURL "images/og-image-fission.png" -}}
+{{- if .IsHome -}}
+{{- $home := dict
+  "@context" "https://schema.org"
+  "@graph" (slice
+    $org
+    (dict
+      "@type" "WebSite"
+      "name" site.Title
+      "url" site.BaseURL
+      "description" site.Params.description
+      "publisher" $org)
+    (dict
+      "@type" "SoftwareApplication"
+      "name" "Fission"
+      "url" site.BaseURL
+      "description" site.Params.description
+      "applicationCategory" "DeveloperApplication"
+      "operatingSystem" "Kubernetes"
+      "softwareVersion" site.Params.release_version
+      "license" "https://www.apache.org/licenses/LICENSE-2.0"
+      "image" $defaultImage
+      "offers" (dict "@type" "Offer" "price" "0" "priceCurrency" "USD")
+      "sameAs" "https://github.com/fission/fission"))
+-}}
+<script type="application/ld+json">{{ $home | jsonify | safeJS }}</script>
+{{- else if and .IsPage (eq .Section "blog") -}}
+{{- $image := $defaultImage -}}
+{{- with .Params.images -}}
+  {{- with index . 0 -}}{{- $image = absURL (strings.TrimPrefix "/" .) -}}{{- end -}}
+{{- end -}}
+{{- $post := dict
+  "@context" "https://schema.org"
+  "@type" "BlogPosting"
+  "headline" .Title
+  "description" (partial "page-description.html" .)
+  "url" .Permalink
+  "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+  "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+  "image" $image
+  "publisher" $org
+-}}
+{{- with .Params.author -}}
+  {{- $post = merge $post (dict "author" (dict "@type" "Person" "name" .)) -}}
+{{- else -}}
+  {{- $post = merge $post (dict "author" $org) -}}
+{{- end -}}
+<script type="application/ld+json">{{ $post | jsonify | safeJS }}</script>
+{{- else if eq .Section "docs" -}}
+{{- if .IsPage -}}
+{{- $article := dict
+  "@context" "https://schema.org"
+  "@type" "TechArticle"
+  "headline" .Title
+  "description" (partial "page-description.html" .)
+  "url" .Permalink
+  "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+  "image" $defaultImage
+  "author" $org
+  "publisher" $org
+-}}
+<script type="application/ld+json">{{ $article | jsonify | safeJS }}</script>
+{{- end -}}
+{{- $items := slice -}}
+{{- $pos := 1 -}}
+{{- range .Ancestors.Reverse -}}
+  {{- $items = $items | append (dict
+    "@type" "ListItem"
+    "position" $pos
+    "name" (.LinkTitle | plainify)
+    "item" .Permalink) -}}
+  {{- $pos = add $pos 1 -}}
+{{- end -}}
+{{- $items = $items | append (dict
+  "@type" "ListItem"
+  "position" $pos
+  "name" (.LinkTitle | plainify)
+  "item" .Permalink) -}}
+{{- $breadcrumbs := dict
+  "@context" "https://schema.org"
+  "@type" "BreadcrumbList"
+  "itemListElement" $items
+-}}
+<script type="application/ld+json">{{ $breadcrumbs | jsonify | safeJS }}</script>
+{{- end -}}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
## SEO/LLM audit — findings and fixes

Audited the site (templates + live output). Foundations were already solid: canonicals, OG/Twitter cards, 1200×628 OG image, sitemap, http→https + www→apex 301s, RSS, custom 404, 98 legacy redirects. This PR fixes what was missing.

### Structured data (was: none)
- New `layouts/partials/schema.html` — Docsy's head already invokes `partial "schema.html"`, so this lights up everywhere:
  - **Home**: `Organization` + `WebSite` + `SoftwareApplication` (version wired to `params.release_version`, Apache-2.0, repo/social `sameAs`)
  - **Docs pages**: `TechArticle` + `BreadcrumbList` (from page ancestors)
  - **Blog posts**: `BlogPosting` (author, dates, featured image)
- All blocks built with `jsonify`; validated by parsing every emitted `ld+json` block from the built pages.

### LLM-friendly outputs (was: /llms.txt → 404)
- **`/llms.txt`** — markdown site + docs index for AI agents, using Docsy v0.15's native `LLMS` output format (config-only).
- **Markdown mirror** — every page now also renders as plain markdown at `<url>/index.md` (Docsy's `all.md` template); llms.txt links the `.md` URLs automatically. Verified the mirrors stay **out of sitemap.xml**.
- robots.txt now carries the `Sitemap:` line; AI crawlers (GPTBot/ClaudeBot/etc.) deliberately remain allowed.

### Meta descriptions (was: 64 pages missing)
- Hand-written one-sentence descriptions for 28 `usage/` pages and 5 blog pages (each agent read the page first).
- Formulaic descriptions + "vX.Y.Z Release Notes" titles for all 31 release pages (`linkTitle` keeps the sidebar compact).
- **100% description coverage** outside auto-generated CLI reference pages. Descriptions feed meta description, og:description, and the llms.txt/markdown indexes.

### Titles & headings
- Homepage `<title>`/og:title: `Fission` → **"Fission — Open Source Kubernetes-native Serverless Framework"** (landing front matter + a one-block fork of Docsy's `head.html`, commented for re-diff on Docsy bumps).
- One `<h1>` per page: "Join the Community" section headings on home + support demoted to classed `<h2>` (visually identical — verified in browser).

### Conventions
- `.claude/resources/seo.md` captures the rules (description required on every page, JSON-LD entity map, llms output config, title/heading rules), linked from CLAUDE.md.

### Verified
- Clean build with the Netlify-pinned Hugo 0.157.0 (page count 311→525 from the markdown mirrors).
- JSON-LD parses on home/docs/blog; sitemap has 260 HTML URLs and zero `.md` entries; robots.txt correct; homepage renders identically.

### Noted but not changed
- `services.googleAnalytics.id` is empty — analytics appears to run via GTM; confirm the GTM container has GA4.
- Taxonomy pages (`/tags/`, `/author/*`) are thin content; consider `noindex` later if Search Console flags them.
- After merge: re-trigger the Algolia DocSearch crawl so search picks up new descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)