### PR TITLE
SEO follow-ups: noindex taxonomy pages, GA4 verification notes

### DIFF
--- a/.claude/resources/seo.md
+++ b/.claude/resources/seo.md
@@ -37,6 +37,22 @@ Validate after changes: extract `application/ld+json` blocks from built pages an
 - Site title stays the short "Fission" (it suffixes every page title).
 - Home `<title>`/og:title come from the landing page's front-matter title ("Fission — Open Source Kubernetes-native Serverless Framework") via the **forked** `layouts/partials/head.html` (one-block change from Docsy v0.15 — re-diff on Docsy bumps).
 
+## Analytics
+
+- Analytics runs through **GTM container `GTM-NX83GPK`** (inline snippet in `layouts/partials/hooks/head-end.html`), which loads **GA4 `G-BKDL6KWXQX`** (verified by inspecting the served gtm.js; it also carries a dead legacy UA tag).
+- `services.googleAnalytics.id` in config.toml is **intentionally empty** — setting it would make Docsy inject gtag.js alongside GTM and double-count every hit.
+
+## Taxonomy pages
+
+- `/tags/`, `/categories/*`, `/author/*` are thin listings: **noindexed** (`noindex, follow` in the forked `partials/head.html`) and **excluded from sitemap.xml** (`layouts/sitemap.xml` override of Hugo's embedded template).
+They remain crawlable and linked for navigation.
+
+## Search (Algolia DocSearch)
+
+- Config: `[params.search.algolia]` in config.toml (search-only API key — safe to be public).
+- The DocSearch crawler runs on Algolia's infrastructure on its own weekly schedule; the repo cannot trigger a crawl.
+Manual re-crawl: https://crawler.algolia.com/ with the DocSearch account that owns app `MSV5TDX060`.
+
 ## Plumbing
 
 - `layouts/robots.txt` → `/robots.txt` with the `Sitemap:` line (`enableRobotsTXT = true`).

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -46,7 +46,11 @@
 {{ end -}}
 
 {{ $outputFormat := partial "outputformat.html" . -}}
-{{ if and hugo.IsProduction (ne $outputFormat "print") (ne .Site.Language.Lang "xx") -}}
+{{/* Site change vs upstream: taxonomy pages (/tags/, /categories/, /author/*)
+     are thin listings — keep them crawlable but out of the index. */ -}}
+{{ if in (slice "taxonomy" "term") .Kind -}}
+<meta name="robots" content="noindex, follow">
+{{ else if and hugo.IsProduction (ne $outputFormat "print") (ne .Site.Language.Lang "xx") -}}
 <meta name="robots" content="index, follow">
 {{ else -}}
 <meta name="robots" content="noindex, nofollow">

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,26 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+{{/* Hugo's embedded sitemap template, minus taxonomy/term pages —
+     those are noindexed (see partials/head.html), so keep them out here too. */}}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{- if and .Permalink (not (in (slice "taxonomy" "term") .Kind)) }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML (.Lastmod.Format "2006-01-02T15:04:05-07:00") }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+      rel="alternate"
+      hreflang="{{ .Language.LanguageCode }}"
+      href="{{ .Permalink }}"
+      />{{ end }}
+    <xhtml:link
+      rel="alternate"
+      hreflang="{{ .Language.LanguageCode }}"
+      href="{{ .Permalink }}"
+      />{{ end }}
+  </url>
+    {{- end }}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
Closes out the remaining items from the SEO audit (#289).

## Taxonomy pages → noindex + out of sitemap
`/tags/`, `/categories/*`, and `/author/*` are thin listing pages (tags is empty, categories has 3 terms).
They now emit `noindex, follow` and are excluded from `sitemap.xml` (260 → 238 URLs) while staying crawlable and linked for navigation.
Verified in the built output: taxonomy pages noindexed, home/docs/blog still `index, follow`, zero taxonomy URLs in the sitemap.

## GA4 — verified, no change needed
Inspected the served GTM container (`GTM-NX83GPK`): it loads **GA4 `G-BKDL6KWXQX`** (plus a dormant legacy UA tag).
`services.googleAnalytics.id` stays intentionally empty — setting it would have Docsy inject gtag.js next to GTM and double-count traffic.
Documented in `.claude/resources/seo.md`.

## Algolia DocSearch
The crawler runs on Algolia's infra on its own weekly schedule — nothing in-repo can trigger it.
For an immediate re-crawl after these merges: https://crawler.algolia.com/ with the account owning app `MSV5TDX060`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)