### PR TITLE
Update README and CONTRIBUTING to match current repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,64 @@
 # Contributing
 
-There are many areas we can use contributions - ranging from code, documentation, feature proposals, issue triage, samples, and content creation. 
+There are many areas we can use contributions — ranging from documentation, blog posts, feature proposals, issue triage, samples, and content creation.
 
 First, please read the [code of conduct](https://github.com/fission/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you're expected to uphold this code.
 
+## Prerequisites
+
+- **Hugo (extended)** and **Go** — the exact versions Netlify builds with are pinned in [`netlify.toml`](netlify.toml) (`HUGO_VERSION`, `GO_VERSION`); use the same Hugo version locally, behavior differs across releases.
+Go is needed because the [Docsy](https://www.docsy.dev) theme is loaded as a Hugo Module (declared in `go.mod` — there are **no git submodules** to initialize).
+- **Node.js (LTS)** — for the PostCSS toolchain.
+
 ## Setup
 
-1. Clone and setup
-```sh
-# Clone all submodules
-git submodule update --init --recursive
-# Install NPM dependencies
-npm install
-```
-2. Run Hugo server
-```
-$ hugo server
-Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
-Press Ctrl+C to stop
-```
-You can visit [localhost:1313](http://localhost:1313/) in browser to preview website.
+1. Clone the repo and install NPM dependencies
+
+    ```sh
+    npm install
+    ```
+
+2. Run the Hugo server
+
+    ```sh
+    $ hugo server
+    Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
+    Press Ctrl+C to stop
+    ```
+
+    Visit [localhost:1313](http://localhost:1313/) to preview the site.
+    Hugo downloads the Docsy module automatically on first run.
+
+3. (Optional) Run the full production build — exactly what Netlify runs:
+
+    ```sh
+    ./build.sh
+    ```
 
 ## Making changes
 
-1. Create a new branch
-2. Make your changes
-3. Verify your changes locally with Hugo server
-4. Commit and push your changes to the branch
-5. Raise a PR to default branch, verify changes with Netlify preview URL
-6. Once PR is merged, your changes would be live on the site
+1. Create a new branch.
+2. Make your changes.
+3. Verify locally with the Hugo server; for template/partial changes restart the server (Docsy caches partials).
+4. Run `./build.sh` to make sure the production build passes with no warnings.
+5. Commit and push your changes to the branch.
+6. Raise a PR to the default branch and verify your changes on the Netlify deploy-preview URL posted on the PR.
+7. Once the PR is merged, your changes go live automatically.
+
+## Authoring conventions
+
+- **Every page needs a front-matter `description:`** — one factual sentence; it becomes the meta description and the page's entry in `/llms.txt`.
+- **Never hardcode Fission versions** in prose — use the `{{< release-version >}}` and `{{< chart-version >}}` shortcodes (values come from `config.toml`).
+- **Internal links** are plain absolute URLs (`/docs/installation/upgrade/`); don't use the `relref` shortcode on regular pages.
+- **One sentence per line** in Markdown — rendering is identical, but diffs and reviews become per-sentence.
+- **Diagrams** are written as Mermaid code fences and follow the site's color/width conventions.
+- **Moving or renaming a page?** Add a redirect in `netlify.toml` so inbound links keep working.
+- Auto-generated reference pages (`docs/reference/fission-cli/*`, `crd-reference.md`, `metrics-reference.md`) are regenerated from the Fission codebase — don't hand-edit them.
+
+Detailed conventions (design system, Mermaid diagram rules, page skeletons, SEO rules) live in [`.claude/resources/`](.claude/resources/), and [`CLAUDE.md`](CLAUDE.md) gives AI coding assistants the same guidance.
+
+## Common content tasks
+
+- **Blog post** — front-matter template, featured-image workflow, and category conventions: see `.claude/skills/writing-blog-posts/`.
+- **New language environment or example** — both catalog pages are data-driven from `static/data/*.json`: see `.claude/skills/updating-environments-and-examples/` and [`tools/README.md`](tools/README.md).
+- **Docs for a new Fission release** — version bumps, release-notes page, compatibility matrix: see `.claude/skills/cutting-fission-release-docs/`.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,38 @@
-# Fission Site Source Repo
+# Fission Website Source
 
-This is the source for the [fission.io](https://fission.io)
-website.
+Source for [fission.io](https://fission.io) — the website and documentation for the [Fission](https://github.com/fission/fission) serverless framework.
+
+## How the site is built
+
+- [Hugo](https://gohugo.io) static site using the [Docsy](https://www.docsy.dev) theme.
+Docsy is pulled in as a **Hugo Module** via `go.mod` (no git submodules).
+- Hosted on [Netlify](https://netlify.com), which builds every push and every PR (deploy previews) by running `./build.sh`.
+- Exact build tool versions are pinned in `netlify.toml` (Hugo extended + Go) — match them locally when reproducing CI builds.
+- `npm install` provides the PostCSS toolchain Docsy needs.
 
 ## Repo organization
 
-This is a [hugo](https://gohugo.io) statically-generated site, hosted
-on [netlify](https://netlify.com).  The site is automatically built by
-netlify (see netlify.toml and build.sh).
-
-All site content is stored in the `content` directory in markdown format.
-
 ```text
 content/en
-├── _index.html  # Landing page
-├── author       # Info about blog authors
-├── blog         # Blog posts
-├── docs         # Documentation pages
-└── search.md
+├── _index.html   # Landing page
+├── docs          # Documentation (getting-started, concepts, architecture,
+│                 #   installation, usage, trouble-shooting, reference, releases)
+├── blog          # Blog posts
+├── environments  # Language runtimes catalog (data-driven)
+├── examples      # Function examples catalog (data-driven)
+├── support       # Commercial support and community page
+└── author        # Blog author taxonomy pages
+
+assets/scss       # Project styles (_variables_project.scss)
+layouts           # Site-level template overrides (blog list, head, schema, shortcodes)
+static/data       # environments.json / examples.json behind the catalog pages
+static/images     # Images, logos, blog featured images
+tools             # Helper scripts (environments.json refresh, release notes formatting)
 ```
+
+- Versioned values (Fission release, Helm chart) live in `config.toml` (`release_version`, `chart_version`) and are referenced in content through the `{{< release-version >}}` / `{{< chart-version >}}` shortcodes.
+- The site also serves machine-readable outputs for AI tools: [`/llms.txt`](https://fission.io/llms.txt) and a markdown mirror of every page at `<url>/index.md`.
 
 ## Contributing
 
-### Setup
-
-1. Clone and setup
-
-    ```sh
-    # Install NPM dependencies with Node LTS version
-    npm install
-    ```
-
-2. Run Hugo server
-
-    ```sh
-    $ hugo server
-    Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
-    Press Ctrl+C to stop
-    ```
-
-You can visit [localhost:1313](http://localhost:1313/) in browser to preview website.
-
-### Making changes
-
-1. Create a new branch
-2. Make your changes
-3. Verify your changes locally with Hugo server
-4. Commit and push your changes to the branch
-5. Raise a PR to default branch, verify changes with Netlify preview URL
-6. Once PR is merged, your changes would be live on the site
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, the preview workflow, and authoring conventions.


### PR DESCRIPTION
Refreshes the two top-level docs to match how the repo actually works today:

**Fixed stale facts**
- `git submodule update --init --recursive` removed — Docsy has been a **Hugo Module** (`go.mod`) for a long time; `.gitmodules` is empty and the step did nothing.
- Prerequisites now point at `netlify.toml` as the source of truth for the pinned Hugo (extended) + Go versions, plus Node LTS for PostCSS.

**README**
- Current content tree including the `environments`/`examples`/`support` sections, `assets/scss`, `layouts`, `static/data`, and `tools`.
- Mentions the version shortcodes (`release_version`/`chart_version` in config.toml) and the new `/llms.txt` + markdown mirror outputs.
- No longer duplicates the contributing guide — links to CONTRIBUTING.md instead.

**CONTRIBUTING**
- Full workflow: hugo server (with the restart-after-partial-edits gotcha), `./build.sh` as the local gate, Netlify deploy-preview verification.
- New "Authoring conventions" section: required front-matter descriptions, version shortcodes, absolute internal links (no relref), one sentence per line, redirects on page moves, hands off auto-generated reference pages.
- Pointers to `.claude/resources/` and the `.claude/skills/` walkthroughs for common tasks (blog posts, environments/examples updates, release docs).

Build verified clean with the Netlify-pinned Hugo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)