### PR TITLE
Doc changes v1.26.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -116,8 +116,8 @@ privacy_policy = ""
 # current release branch - could be rc
 release_branch = "main"
 # the main version. Never is rc.
-release_version = "v1.25.0"
-chart_version = "1.25.0"
+release_version = "v1.26.0"
+chart_version = "1.26.0"
 
 slackurl = "/slack"
 
@@ -185,12 +185,12 @@ twitter = 'fissionio'
 
 [[params.whatsnew]]
 badge = 'RELEASE'
-body = 'Fission v1.25.0 is out! Kubernetes 1.32 support, stricter admission with API-server CEL validation, PodSpec capability allowlist, and more.'
-heading = 'Announcing Fission v1.25.0'
+body = 'Fission v1.26.0 is out! OCI-native package delivery, the Kubernetes Gateway API route provider, streaming responses (SSE/chunked/WebSocket), and functions as MCP tools.'
+heading = 'Announcing Fission v1.26.0'
 [params.whatsnew.button]
 hero_class = 'mid'
 text = 'Read Release Notes'
-url = '/docs/releases/v1.25.0/'
+url = '/docs/releases/v1.26.0/'
 
 [[params.whatsnew]]
 badge = 'BLOG'

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -340,15 +340,15 @@ images: ["images/og-image-fission.png"]
         <div class="card-shadow">
           <span class="card-badge">RELEASE</span>
           <h4 class="section-text-bold mt-4">
-            Announcing Fission <span class="d-lg-block">v1.25.0</span>
+            Announcing Fission <span class="d-lg-block">v1.26.0</span>
           </h4>
           <div class="card-shadow-content">
             <p class="section-text">
-              Fission v1.25.0 is out! Kubernetes 1.32 support, stricter
-              admission with API-server CEL validation, PodSpec capability
-              allowlist, and more.
+              Fission v1.26.0 is out! OCI-native package delivery, the
+              Kubernetes Gateway API route provider, streaming responses, and
+              functions as MCP tools.
             </p>
-            <a href="/docs/releases/v1.25.0/"
+            <a href="/docs/releases/v1.26.0/"
               ><button class="hero-mid align-self-end">Release Notes</button></a
             >
           </div>

--- a/content/en/blog/websocket-sample.md
+++ b/content/en/blog/websocket-sample.md
@@ -9,6 +9,12 @@ type = "blog"
 
 ## Introduction
 
+> **Recommended: the streaming WebSocket path.**
+> Since Fission v1.26.0, WebSocket is first-class for **every** environment through the streaming invocation path (`fission fn create ... --streaming --streamingprotocol websocket`) — not just the NodeJS/Python built-in support this post describes.
+> The router upgrades the connection and holds the function pod for the socket's lifetime, so you no longer need the event-based keepalive mechanism (the Python `socket_tracker.py` / fetcher `/wsevent` endpoints), which is now deprecated.
+> The `main(ws, clients)` model below is unchanged.
+> See [Streaming responses](https://fission.io/docs/usage/function/streaming/) for the current approach.
+
 In this post we will look into how we can develop a simple a web socket based chat application using Fission functions.
 Fission's [NodeJS environment][15] now has built in support for [WebSocket][1].
 So, we are going to use this environment to power our simple web based chat application.

--- a/content/en/docs/architecture/storagesvc.md
+++ b/content/en/docs/architecture/storagesvc.md
@@ -15,6 +15,12 @@ It is reached only over the cluster network by the builder pods, function-pod fe
 Packages whose archive is **larger than 256 KB** are stored in StorageSvc rather than inline in the `Package` resource; smaller archives are stored as literals in the CRD itself.
 A builder pod uploads the deployment archive it produces to StorageSvc, and the fetcher inside a function pod downloads that archive when specializing the function.
 
+{{% notice info %}}
+Since v1.26.0, when a package registry is configured (`packageRegistry.enabled`), a build's deployment archive is instead published as a digest-pinned **OCI image** and pulled at cold start, bypassing StorageSvc for that package.
+StorageSvc remains the default and the fallback (`fallbackToStorage`) when no registry is configured or a push fails, and source archives always use StorageSvc.
+See [OCI image packages]({{% ref "/docs/usage/function/oci-packages.md" %}}).
+{{% /notice %}}
+
 ## Storage backends
 
 StorageSvc abstracts over two object-store backends, selected by the `persistence.storageType` Helm value:

--- a/content/en/docs/concepts/functions.md
+++ b/content/en/docs/concepts/functions.md
@@ -71,9 +71,11 @@ The fields you most often set are:
 - **`idletimeout`** — how long a function may sit idle before its pods are reaped.
 - **`concurrency`** and **`requestsPerPod`** — how many pods may be specialized and how many concurrent requests each pod serves.
 - **`secrets`** and **`configmaps`** — Kubernetes Secrets and ConfigMaps made available to the function.
+- **`streaming`** — optional; opt the function into incremental (SSE / chunked / WebSocket) responses. When set, the response is governed by `idleTimeoutSeconds` (and an optional `maxDurationSeconds`) instead of `functionTimeout`. See [Streaming responses]({{% ref "/docs/usage/function/streaming.md" %}}).
+- **`tool`** — optional; advertise the function as a [Model Context Protocol tool]({{% ref "/docs/usage/function/mcp-tools.md" %}}) so LLM agents can discover and invoke it.
 
 {{% notice info %}}
-The `Function` resource has a status subresource with Conditions, so you can inspect reconciliation state with `kubectl get function <name> -o yaml`.
+The `Function` resource has a status subresource with Conditions, so you can inspect reconciliation state with `kubectl get function <name> -o yaml` — or wait on it directly with `kubectl wait --for=condition=Ready function/<name>`.
 {{% /notice %}}
 
 A function references exactly one environment.
@@ -81,7 +83,7 @@ Several functions can share a single package by using different `functionName` e
 
 ## Defaults worth knowing
 
-- **Function timeout** defaults to 60 seconds when `functionTimeout` is unset.
+- **Function timeout** defaults to 60 seconds when `functionTimeout` is unset. This cap does **not** apply to [streaming functions]({{% ref "/docs/usage/function/streaming.md" %}}), which are governed by a stream idle timeout instead.
 - **Concurrency** (maximum pods specialized for a function) defaults to 500.
 - **Requests per pod** defaults to 1, meaning each specialized pod serves one request at a time unless you raise it.
 

--- a/content/en/docs/concepts/packages-and-builds.md
+++ b/content/en/docs/concepts/packages-and-builds.md
@@ -75,22 +75,28 @@ flowchart TB
 5. The builder manager records the upload result, sets `buildstatus: succeeded`, and updates dependent functions so they pick up the new archive.
 
 {{% notice warning %}}
-As of {{< release-version >}}, builder pods no longer inherit the builder service-account token, and cross-namespace Environment or Package references are rejected.
+As of v1.24.0, builder pods no longer inherit the builder service-account token, and cross-namespace Environment or Package references are rejected.
 Keep a function's environment and package in the same namespace.
 {{% /notice %}}
 
-## Literal vs URL archives, and checksums
+## Literal, URL, and OCI archives
 
-An archive is stored in one of two ways, set by its `type`:
+A deployment archive is delivered in one of three ways, set by its `type`:
 
 - **`literal`** — the archive bytes are embedded directly in the resource, suitable for small packages.
 - **`url`** — the archive is referenced by URL and fetched on demand, suitable for larger artifacts stored externally (for example, in the storage service).
+- **`oci`** — the deployment code is the filesystem of an **OCI image** in a container registry, pulled at cold start. Available since v1.26.0 and for deployment archives only. See [OCI image packages]({{% ref "/docs/usage/function/oci-packages.md" %}}).
 
 URL archives carry a **checksum** so Fission can verify integrity when fetching.
 The only supported checksum type is `sha256`, enforced by a CEL rule on the resource; the sum is hex-encoded.
-Checksums are ignored for literal archives, where the bytes are already present.
+Checksums are ignored for literal archives, where the bytes are already present; OCI archives can instead be pinned to an image `digest`.
 
 You can point a function at an externally hosted archive over a URL; see [URL as archive source]({{% ref "/docs/usage/function/url-as-archive-source.md" %}}).
+
+{{% notice info %}}
+When a [package registry]({{% ref "/docs/usage/function/oci-packages.md" %}}) is configured cluster-wide, the builder publishes each successful build's deployment archive as a digest-pinned OCI image and functions cold-start from it (with a tarball fallback through the storage service).
+Without a registry configured, builds use the storage-service path described above unchanged.
+{{% /notice %}}
 
 ## Related
 

--- a/content/en/docs/installation/compatibility.md
+++ b/content/en/docs/installation/compatibility.md
@@ -16,6 +16,7 @@ The **Tested with** column lists the `kindest/node` images each release's CI run
 | Fission version | Built against (`k8s.io/api`) | Tested with (kind) | Minimum Kubernetes |
 | --------------- | ---------------------------- | ------------------ | ------------------ |
 | {{< release-version >}} | v0.36 | 1.32, 1.34, 1.36 | **1.32** |
+| v1.25.0 | v0.36 | 1.32, 1.34, 1.36 | 1.32 |
 | v1.24.0 | v0.35 | 1.28, 1.32, 1.34 | 1.28 |
 | v1.23.0 | v0.35 | 1.28, 1.32, 1.34 | 1.28 |
 | v1.22.0 | v0.34 | 1.28, 1.32, 1.34 | 1.28 |
@@ -38,6 +39,7 @@ From v1.21.0 onward, KEDA is a direct Go dependency of Fission and the table bel
 | Fission version | KEDA version |
 | --------------- | ------------ |
 | {{< release-version >}} | v2.20 |
+| v1.25.0 | v2.20 |
 | v1.24.0 | v2.19 |
 | v1.23.0 | v2.18 |
 | v1.22.0 | v2.18 |

--- a/content/en/docs/installation/upgrade.md
+++ b/content/en/docs/installation/upgrade.md
@@ -34,9 +34,21 @@ helm upgrade --namespace $FISSION_NAMESPACE fission fission-charts/fission-all
 
 _See [configuration](#configuration) below._
 
-## Upgrade to {{< release-version >}} release
+## Upgrade to 1.26.x release
 
-{{< release-version >}} raises the minimum supported Kubernetes version to **1.32** and continues the security-hardening line.
+v1.26.0 is a large feature release: OCI-native package delivery, the Kubernetes Gateway API route provider, streaming responses, functions as MCP tools, and an EndpointSlice-native router data plane.
+There are no Kubernetes-version or admission changes from v1.25.0, so the routine CRD/CLI/chart steps above are all most installs need.
+
+Two behavioral defaults are worth reviewing before you upgrade:
+
+- The router now serves warm traffic directly from EndpointSlices and accounts request concurrency **per router replica** by default. Functions that depend on global concurrency enforcement should set the `fission.io/concurrency-enforcement: strict` annotation.
+- When a package registry is configured (`packageRegistry.enabled`), builds publish their deployment archive as a digest-pinned OCI image and functions cold-start from it. Leave `packageRegistry.enabled` unset to keep today's tarball behavior unchanged.
+
+See the [v1.26.0 release notes](/docs/releases/v1.26.0/#upgrade-notes) for the full list of behavioral changes and the action each one requires.
+
+## Upgrade to 1.25.x release
+
+v1.25.0 raises the minimum supported Kubernetes version to **1.32** and continues the security-hardening line.
 Before upgrading, confirm your cluster is on Kubernetes 1.32 or newer — the Helm chart now refuses to install on anything older.
 
 Three breaking changes need attention:
@@ -49,7 +61,7 @@ The HTTPTrigger / TimeTrigger / CanaryConfig admission webhooks are also removed
 A side effect: a raw `kubectl apply` of an invalid cron schedule, CORS origin, or ingress path is now **admitted and flagged with a `…=False` status condition** (for example `Scheduled=False`, `RouteAdmitted=False`) rather than rejected at creation.
 The `fission` CLI still rejects these client-side, so the common path is unchanged.
 
-See the [{{< release-version >}} release notes]({{% ref "../releases/v1.25.0.md" %}}#upgrade-notes) for the full list of breaking changes and the action each one requires.
+See the [v1.25.0 release notes](/docs/releases/v1.25.0/#upgrade-notes) for the full list of breaking changes and the action each one requires.
 
 ## Upgrade to 1.24.x release
 

--- a/content/en/docs/reference/crd-reference.md
+++ b/content/en/docs/reference/crd-reference.md
@@ -46,6 +46,12 @@ _Appears in:_
 
 Archive contains or references a collection of sources or
 binary files.
+The CEL rule below deliberately never references self.literal: any
+access to a byte-format field (even has()) makes the apiserver convert
+its base64 value for CEL using URL-safe decoding, which rejects any
+standard-base64 payload containing '/' or '+' — in practice every
+zipped literal archive. The literal/oci combination is instead
+rejected by the webhook (Archive.Validate), with the same message.
 
 
 
@@ -54,19 +60,19 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[ArchiveType](#archivetype)_ | Type defines how the package is specified: literal or URL.<br />Available value:<br /> - literal<br /> - url |  | Enum: [ literal url] <br /> |
+| `type` _[ArchiveType](#archivetype)_ | Type defines how the package is specified: literal, URL, or OCI.<br />Available value:<br /> - literal<br /> - url<br /> - oci |  | Enum: [ literal url oci] <br /> |
 | `literal` _integer array_ | Literal contents of the package. Can be used for<br />encoding packages below TODO (256 KB?) size. |  |  |
 | `url` _string_ | URL references a package. |  |  |
 | `checksum` _[Checksum](#checksum)_ | Checksum ensures the integrity of packages<br />referenced by URL. Ignored for literals. |  |  |
+| `oci` _[OCIArchive](#ociarchive)_ | OCI references an OCI image holding the deployment code.<br />Mutually exclusive with Literal and URL. Supported only on<br />PackageSpec.Deployment; PackageSpec.Validate rejects it on Source<br />(source archives feed the builder, which has no OCI pull path). |  |  |
 
 
 #### ArchiveType
 
 _Underlying type:_ _string_
 
-ArchiveType is either literal or URL, indicating whether
-the package is specified in the Archive struct or
-externally.
+ArchiveType is literal, url, or oci, indicating whether the
+package is specified in the Archive struct or externally.
 
 
 
@@ -77,6 +83,7 @@ _Appears in:_
 | --- | --- |
 | `literal` | ArchiveTypeLiteral means the package contents are specified in the Literal field of<br />resource itself.<br /> |
 | `url` | ArchiveTypeUrl means the package contents are at the specified URL.<br /> |
+| `oci` | ArchiveTypeOCI means the package contents are the filesystem of an<br />OCI image referenced in the OCI field of the resource.<br /> |
 
 
 
@@ -476,6 +483,8 @@ _Appears in:_
 | `InvokeStrategy` _[InvokeStrategy](#invokestrategy)_ | InvokeStrategy is a set of controls which affect how function executes |  |  |
 | `functionTimeout` _integer_ | FunctionTimeout provides a maximum amount of duration within which a request for<br />a particular function execution should be complete.<br />This is optional. If not specified default value will be taken as 60s |  |  |
 | `idletimeout` _integer_ | IdleTimeout specifies the length of time that a function is idle before the<br />function pod(s) are eligible for deletion. If no traffic to the function<br />is detected within the idle timeout, the executor will then recycle the<br />function pod(s) to release resources. |  |  |
+| `streaming` _[StreamingConfig](#streamingconfig)_ | Streaming opts this function into the router's streaming invocation path:<br />incremental flushing, an idle/max timeout split, and a router-driven pod<br />keepalive for the connection's lifetime. When nil (the default) the function<br />uses the classic buffered, retry-on-transient-error proxy path with a single<br />FunctionTimeout deadline. Additive and backward compatible. |  |  |
+| `tool` _[ToolConfig](#toolconfig)_ | Tool, when non-nil, advertises this function as a Model Context Protocol<br />(MCP) tool on the fission-bundle --mcpPort server. The MCP server watches<br />Function CRDs and hot-updates its tool list from this field. Presence is<br />the on switch (like Streaming): nil (the default) means the function is<br />never advertised as a tool. Additive and backward compatible. |  |  |
 | `concurrency` _integer_ | Maximum number of pods to be specialized which will serve requests<br />This is optional. If not specified default value will be taken as 500 |  |  |
 | `requestsPerPod` _integer_ | RequestsPerPod indicates the maximum number of concurrent requests that can be served by a specialized pod<br />This is optional. If not specified default value will be taken as 1 |  |  |
 | `onceOnly` _boolean_ | OnceOnly specifies if specialized pod will serve exactly one request in its lifetime and would be garbage collected after serving that one request<br />This is optional. If not specified default value will be taken as false |  |  |
@@ -498,6 +507,43 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `observedGeneration` _integer_ | ObservedGeneration reflects the .metadata.generation that the<br />controller observed when it last updated the status. |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest observations of the function's state. |  |  |
+
+
+#### GatewayParentRef
+
+
+
+GatewayParentRef references a Gateway (and optionally a specific listener)
+that the generated HTTPRoute attaches to. It mirrors the subset of
+gateway.networking.k8s.io ParentReference that Fission needs.
+
+
+
+_Appears in:_
+- [GatewayRouteConfig](#gatewayrouteconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the parent Gateway. |  |  |
+| `namespace` _string_ | Namespace of the parent Gateway. Defaults to the router's namespace<br />when empty. A non-empty, different namespace needs a ReferenceGrant. |  |  |
+| `sectionName` _string_ | SectionName selects a specific listener on the Gateway. Empty attaches<br />to all compatible listeners. |  |  |
+| `port` _integer_ | Port narrows attachment to a specific Gateway listener port. |  | Maximum: 65535 <br />Minimum: 1 <br /> |
+
+
+#### GatewayRouteConfig
+
+
+
+GatewayRouteConfig is the Gateway-API-specific portion of a RouteConfig.
+
+
+
+_Appears in:_
+- [RouteConfig](#routeconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `parentRefs` _[GatewayParentRef](#gatewayparentref) array_ | ParentRefs are the Gateways the generated HTTPRoute attaches to. The<br />referenced Gateways are owned by the cluster operator (Fission does<br />not create Gateways or GatewayClasses). A cross-namespace parentRef<br />requires a ReferenceGrant in the Gateway's namespace. |  |  |
 
 
 #### HTTPTrigger
@@ -566,8 +612,9 @@ _Appears in:_
 | `method` _string_ | Use Methods instead of Method. This field is going to be deprecated in a future release<br />HTTP method to access a function. |  | Enum: [ GET HEAD POST PUT PATCH DELETE CONNECT OPTIONS TRACE] <br /> |
 | `methods` _string array_ | HTTP methods to access a function |  | items:Enum: [GET HEAD POST PUT PATCH DELETE CONNECT OPTIONS TRACE] <br /> |
 | `functionref` _[FunctionReference](#functionreference)_ | FunctionReference is a reference to the target function. |  |  |
-| `createingress` _boolean_ | If CreateIngress is true, router will create an ingress definition. |  |  |
-| `ingressconfig` _[IngressConfig](#ingressconfig)_ | IngressConfig for router to set up Ingress. |  |  |
+| `createingress` _boolean_ | If CreateIngress is true, router will create an ingress definition.<br />Deprecated: the Kubernetes Ingress API is frozen. Use RouteConfig<br />(with Provider "gateway") to expose functions through the Gateway API<br />instead. CreateIngress + IngressConfig keep working for the<br />deprecation window but will be removed in a future release. |  |  |
+| `ingressconfig` _[IngressConfig](#ingressconfig)_ | IngressConfig for router to set up Ingress.<br />Deprecated: superseded by RouteConfig. See CreateIngress. |  |  |
+| `routeConfig` _[RouteConfig](#routeconfig)_ | RouteConfig declares how the router exposes this trigger through an<br />external route provider (Ingress or the Gateway API). It is the<br />provider-neutral successor to CreateIngress + IngressConfig: when set<br />it takes precedence over those fields. Leave nil to expose the<br />function only through the router's own URL. |  |  |
 | `corsConfig` _[HTTPTriggerCorsConfig](#httptriggercorsconfig)_ | CorsConfig configures CORS response headers for browser<br />callers of this trigger. When nil, the router emits no<br />Access-Control-* headers and the browser's Same-Origin<br />Policy enforces cluster isolation from cross-origin pages<br />(the deny-by-default behaviour). Set this field to<br />allowlist specific origins for SPAs that legitimately<br />call this trigger cross-origin. |  |  |
 
 
@@ -593,6 +640,8 @@ _Appears in:_
 
 
 IngressConfig is for router to set up Ingress.
+Deprecated: superseded by RouteConfig. The Kubernetes Ingress API is
+frozen; use RouteConfig with Provider "gateway" for new triggers.
 
 
 
@@ -770,6 +819,28 @@ _Appears in:_
 
 
 
+#### OCIArchive
+
+
+
+OCIArchive references an OCI image whose flattened filesystem
+contains the deployment code (RFC-0001). The environment runtime
+image stays the pod's main container; only how the code reaches
+the shared volume changes.
+
+
+
+_Appears in:_
+- [Archive](#archive)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `image` _string_ | Image is a fully qualified OCI reference: registry/repo:tag[@digest]. |  | MinLength: 1 <br /> |
+| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | ImagePullSecrets are resolved when pulling the image. The<br />fetcher-pull path passes them to the in-fetcher keychain; the<br />image-volume path sets them on pod.Spec.ImagePullSecrets.<br />They must exist in the namespace the function pods run in —<br />the function's own namespace, or the configured function<br />namespace for default-namespace functions. |  |  |
+| `subPath` _string_ | SubPath points at the deployment root inside the image<br />filesystem, as a clean relative path; empty means the image<br />root. It must be a directory: the image-volume path mounts it<br />via the pod volumeMount subPath, and kubelets reject file<br />subpaths on image volumes. |  |  |
+| `digest` _string_ | Digest is an optional content hash validated on pull. |  | Pattern: `^sha256:[a-f0-9]\{64\}$` <br /> |
+
+
 #### Package
 
 
@@ -847,6 +918,49 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represent the latest observations of the package's state. |  |  |
 
 
+#### RouteConfig
+
+
+
+RouteConfig declares how the router exposes an HTTPTrigger through an
+external route provider. It is the provider-neutral successor to the
+deprecated CreateIngress + IngressConfig fields: the router routes it to
+the matching RouteProvider based on Provider.
+
+
+
+_Appears in:_
+- [HTTPTriggerSpec](#httptriggerspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `provider` _[RouteProviderType](#routeprovidertype)_ | Provider selects the route provider that reconciles this trigger's<br />external route. "ingress" creates a networking.k8s.io Ingress (the<br />deprecated path); "gateway" creates a gateway.networking.k8s.io<br />HTTPRoute attached to an operator-managed Gateway. The "gateway"<br />provider must be enabled on the router (GATEWAY_API_ENABLED). |  | Enum: [ingress gateway] <br /> |
+| `hostnames` _string array_ | Hostnames the route matches. For the gateway provider these become<br />the HTTPRoute hostnames; for the ingress provider only the first is<br />used as the Ingress rule host. Empty matches all hosts. |  |  |
+| `path` _string_ | Path is the request path the route matches (must be absolute, start<br />with '/'). Defaults to "/" when empty. |  |  |
+| `annotations` _object (keys:string, values:string)_ | Annotations are added to the generated route object (Ingress or<br />HTTPRoute). Use these for implementation-specific configuration<br />understood by your Ingress controller or Gateway implementation. |  |  |
+| `tls` _string_ | TLS names a Secret holding the TLS key and certificate. It applies to<br />the ingress provider only; with the gateway provider TLS termination<br />is configured on the Gateway listener and this field is ignored. |  |  |
+| `gateway` _[GatewayRouteConfig](#gatewayrouteconfig)_ | Gateway holds Gateway-API-specific configuration. Required (at least<br />one parentRef) when Provider is "gateway", unless the router is<br />configured with a default Gateway parentRef. |  |  |
+
+
+#### RouteProviderType
+
+_Underlying type:_ _string_
+
+RouteProviderType selects how the router exposes an HTTPTrigger externally.
+It is the type of RouteConfig.Provider; the allowed values are the constants
+below (also enforced by the field's kubebuilder Enum marker).
+
+
+
+_Appears in:_
+- [RouteConfig](#routeconfig)
+
+| Field | Description |
+| --- | --- |
+| `ingress` | RouteProviderIngress creates a networking.k8s.io Ingress (deprecated).<br /> |
+| `gateway` | RouteProviderGateway creates a gateway.networking.k8s.io HTTPRoute.<br /> |
+
+
 
 
 #### Runtime
@@ -900,6 +1014,47 @@ StrategyType is the strategy to be used for function execution
 _Appears in:_
 - [InvokeStrategy](#invokestrategy)
 
+
+
+#### StreamingConfig
+
+
+
+StreamingConfig controls the router's streaming behavior for a function.
+Presence is the on switch: a non-nil Streaming enables the streaming path,
+nil (the default) is the classic buffered path. There is no separate enabled
+flag, so the in-memory zero value and the stored object never disagree.
+
+
+
+_Appears in:_
+- [FunctionSpec](#functionspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `protocol` _[StreamingProtocol](#streamingprotocol)_ | Protocol hints how the router proxies the response. | auto | Enum: [auto sse chunked websocket] <br /> |
+| `idleTimeoutSeconds` _integer_ | IdleTimeoutSeconds is the maximum time the router waits without bytes flowing<br />from the function before it aborts the stream; reset on every chunk. 0 means<br />use the package default (DefaultStreamIdleSeconds). |  | Minimum: 0 <br /> |
+| `maxDurationSeconds` _integer_ | MaxDurationSeconds is an optional hard ceiling on total stream lifetime<br />regardless of activity. 0 (the default) means no ceiling — the idle<br />timeout governs. A streaming function does NOT inherit FunctionTimeout as<br />a ceiling; that total-wall-clock cap is exactly what streaming escapes. |  | Minimum: 0 <br /> |
+
+
+#### StreamingProtocol
+
+_Underlying type:_ _string_
+
+StreamingProtocol selects how the router treats the upstream response.
+
+_Validation:_
+- Enum: [auto sse chunked websocket]
+
+_Appears in:_
+- [StreamingConfig](#streamingconfig)
+
+| Field | Description |
+| --- | --- |
+| `auto` | StreamingAuto flushes immediately and lets the upstream decide the framing<br />(SSE, chunked, or a WebSocket Upgrade); the safe default.<br /> |
+| `sse` |  |
+| `chunked` |  |
+| `websocket` |  |
 
 
 #### TimeTrigger
@@ -958,6 +1113,29 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `observedGeneration` _integer_ |  |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ |  |  |  |
+
+
+#### ToolConfig
+
+
+
+ToolConfig declares how a Function is exposed as an MCP (Model Context
+Protocol) tool. The MCP server reuses the function's existing internal
+invocation path; this struct only declares the agent-facing tool contract.
+Presence of the enclosing FunctionSpec.Tool is the on switch — there is no
+separate enabled flag, so the in-memory zero value and the stored object
+never disagree (the same rationale as StreamingConfig).
+
+
+
+_Appears in:_
+- [FunctionSpec](#functionspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `description` _string_ | Description is the human/agent-facing tool description surfaced in the MCP<br />tools/list response. Required. |  |  |
+| `inputSchema` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | InputSchema is the JSON Schema (draft 2020-12) for the tool's arguments,<br />surfaced verbatim as the MCP tool inputSchema. Stored as raw JSON so the<br />CRD does not constrain the schema shape. When empty the tool advertises an<br />open object schema (\{"type":"object"\}). |  |  |
+| `toolName` _string_ | ToolName overrides the advertised tool name. Defaults to<br />"<namespace>-<function name>". Must match ^[a-zA-Z0-9_-]\{1,64\}$. |  | Pattern: `^[a-zA-Z0-9_-]\{1,64\}$` <br /> |
 
 
 

--- a/content/en/docs/reference/fission-cli/fission_function.md
+++ b/content/en/docs/reference/fission-cli/fission_function.md
@@ -33,6 +33,7 @@ Create, update and manage functions
 * [fission function pods](/docs/reference/fission-cli/fission_function_pods/)	 - List pods currently used by a function
 * [fission function run-container](/docs/reference/fission-cli/fission_function_run-container/)	 - Alpha: Run a container image as a function
 * [fission function test](/docs/reference/fission-cli/fission_function_test/)	 - Test a function
+* [fission function tools](/docs/reference/fission-cli/fission_function_tools/)	 - List functions exposed as MCP (Model Context Protocol) tools
 * [fission function update](/docs/reference/fission-cli/fission_function_update/)	 - Update a function
 * [fission function update-container](/docs/reference/fission-cli/fission_function_update-container/)	 - Alpha: Update a function running a container
 * [fission function wait](/docs/reference/fission-cli/fission_function_wait/)	 - Wait for a function to reach a status condition

--- a/content/en/docs/reference/fission-cli/fission_function_create.md
+++ b/content/en/docs/reference/fission-cli/fission_function_create.md
@@ -26,6 +26,14 @@ fission function create [flags]
       --idletimeout int             The length of time (in seconds) that a function is idle before pod(s) are eligible for recycling (default 120)
       --concurrency poolmgr         --con |:|: Maximum number of pods specialized concurrently to serve requests (Only valid for executortype; poolmgr) (default 500)
       --requestsperpod poolmgr      --rpp |:|: Maximum number of concurrent requests that can be served by a specialized pod (Only valid for executortype; poolmgr) (default 1)
+      --streaming                   Enable streaming (SSE/chunked/WebSocket) responses for this function; the response is flushed incrementally and not cut by the function timeout
+      --streamingprotocol string    Streaming protocol when --streaming is set; one of 'auto', 'sse', 'chunked', 'websocket' (default "auto")
+      --streamingidletimeout int    Idle timeout (seconds) for a streaming response before it is aborted; reset on each chunk (default 60)
+      --streamingmaxduration int    Hard ceiling (seconds) on total streaming response lifetime; 0 means no ceiling (the idle timeout governs)
+      --expose-as-mcp               Advertise this function as a Model Context Protocol (MCP) tool on the MCP server
+      --tool-description string     Agent-facing tool description (required with --expose-as-mcp)
+      --tool-input-schema string    Path to a JSON Schema file describing the tool's arguments; advertised verbatim as the MCP tool inputSchema
+      --tool-name string            Override the advertised MCP tool name (defaults to <namespace>-<function name>)
       --onceonly poolmgr            --yolo |:|: Specifies if specialized pod will serve exactly one request in its lifetime (Only valid for executortype; poolmgr)
       --labels string               Comma separated labels to apply to the function. E.g. --labels="environment=dev,application=analytics"
       --annotation stringArray      Annotation to apply to the function. To mention multiple annotations --annotation="abc.com/team=dev" --annotation="foo=bar"
@@ -36,6 +44,7 @@ fission function create [flags]
       --srcchecksum string          SHA256 checksum of source archive when providing URL
       --deploychecksum string       SHA256 checksum of deploy archive when providing URL
       --insecure                    Skip generating SHA256 checksum for file integrity validation
+      --oci string                  Pre-built OCI image reference containing the deployment code (registry/repo:tag[@digest])
       --buildcmd string             Package build command for builder to run with
       --url string                  URL pattern (See gorilla/mux supported patterns) [DEPRECATED for 'fn create', use 'route create' instead]
       --prefix string               Prefix with which functions are exposed. NOTE: Prefix takes precedence over URL/RelativeURL [DEPRECATED for 'fn create', use 'route create' instead]

--- a/content/en/docs/reference/fission-cli/fission_function_tools.md
+++ b/content/en/docs/reference/fission-cli/fission_function_tools.md
@@ -1,0 +1,32 @@
+---
+title: fission function tools
+slug: fission_function_tools
+url: /docs/reference/fission-cli/fission_function_tools/
+---
+## fission function tools
+
+List functions exposed as MCP (Model Context Protocol) tools
+
+```
+fission function tools [flags]
+```
+
+### Options
+
+```
+  -o, --output string   -o |:|: Output format: wide, json or yaml (default: table)
+  -h, --help            help for tools
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   Kubernetes context to be used for the execution of Fission commands
+  -n, --namespace string      -n |:|: If present, the namespace scope for this CLI request
+  -v, --verbosity int         -v |:|: CLI verbosity (0 is quiet, 1 is the default, 2 is verbose) (default 1)
+```
+
+### SEE ALSO
+
+* [fission function](/docs/reference/fission-cli/fission_function/)	 - Create, update and manage functions
+

--- a/content/en/docs/reference/fission-cli/fission_function_update.md
+++ b/content/en/docs/reference/fission-cli/fission_function_update.md
@@ -26,6 +26,14 @@ fission function update [flags]
       --idletimeout int             The length of time (in seconds) that a function is idle before pod(s) are eligible for recycling (default 120)
       --concurrency poolmgr         --con |:|: Maximum number of pods specialized concurrently to serve requests (Only valid for executortype; poolmgr) (default 500)
       --requestsperpod poolmgr      --rpp |:|: Maximum number of concurrent requests that can be served by a specialized pod (Only valid for executortype; poolmgr) (default 1)
+      --streaming                   Enable streaming (SSE/chunked/WebSocket) responses for this function; the response is flushed incrementally and not cut by the function timeout
+      --streamingprotocol string    Streaming protocol when --streaming is set; one of 'auto', 'sse', 'chunked', 'websocket' (default "auto")
+      --streamingidletimeout int    Idle timeout (seconds) for a streaming response before it is aborted; reset on each chunk (default 60)
+      --streamingmaxduration int    Hard ceiling (seconds) on total streaming response lifetime; 0 means no ceiling (the idle timeout governs)
+      --expose-as-mcp               Advertise this function as a Model Context Protocol (MCP) tool on the MCP server
+      --tool-description string     Agent-facing tool description (required with --expose-as-mcp)
+      --tool-input-schema string    Path to a JSON Schema file describing the tool's arguments; advertised verbatim as the MCP tool inputSchema
+      --tool-name string            Override the advertised MCP tool name (defaults to <namespace>-<function name>)
       --onceonly poolmgr            --yolo |:|: Specifies if specialized pod will serve exactly one request in its lifetime (Only valid for executortype; poolmgr)
       --labels string               Comma separated labels to apply to the function. E.g. --labels="environment=dev,application=analytics"
       --annotation stringArray      Annotation to apply to the function. To mention multiple annotations --annotation="abc.com/team=dev" --annotation="foo=bar"
@@ -36,6 +44,7 @@ fission function update [flags]
       --srcchecksum string          SHA256 checksum of source archive when providing URL
       --deploychecksum string       SHA256 checksum of deploy archive when providing URL
       --insecure                    Skip generating SHA256 checksum for file integrity validation
+      --oci string                  Pre-built OCI image reference containing the deployment code (registry/repo:tag[@digest])
       --buildcmd string             Package build command for builder to run with
   -f, --force                       -f |:|: Force update a package even if it is used by one or more functions
       --mincpu int                  Minimum CPU to be assigned to pod (In millicore, minimum 1)

--- a/content/en/docs/reference/fission-cli/fission_httptrigger_create.md
+++ b/content/en/docs/reference/fission-cli/fission_httptrigger_create.md
@@ -18,10 +18,16 @@ fission httptrigger create [flags]
       --url string                      URL pattern (See gorilla/mux supported patterns) [DEPRECATED for 'fn create', use 'route create' instead]
       --name string                     HTTP trigger name
       --method stringArray              HTTP Methods: GET,POST,PUT,DELETE,HEAD. To mention single method: --method GET and for multiple methods --method GET --method POST. [DEPRECATED for 'fn create', use 'route create' instead] (default [GET])
-      --createingress                   Creates ingress with same URL
-      --ingressrule string              Host for Ingress rule: --ingressrule host=path (the format of host/path depends on what ingress controller you used)
-      --ingressannotation stringArray   Annotation for Ingress: --ingressannotation key=value (the format of annotation depends on what ingress controller you used)
-      --ingresstls string               Name of the Secret contains TLS key and crt for Ingress (the usability of TLS features depends on what ingress controller you used)
+      --createingress                   Creates ingress with same URL [DEPRECATED: the Kubernetes Ingress API is frozen, use --route-provider gateway instead]
+      --ingressrule string              Host for Ingress rule: --ingressrule host=path (the format of host/path depends on what ingress controller you used) [DEPRECATED: use --route-host/--route-path]
+      --ingressannotation stringArray   Annotation for Ingress: --ingressannotation key=value (the format of annotation depends on what ingress controller you used) [DEPRECATED: use --route-annotation]
+      --ingresstls string               Name of the Secret contains TLS key and crt for Ingress (the usability of TLS features depends on what ingress controller you used) [DEPRECATED: use --route-tls]
+      --route-provider string           Route provider that exposes the function externally: one of 'ingress' or 'gateway' (Gateway API HTTPRoute). When set, takes precedence over --createingress.
+      --route-host stringArray          Hostname the route matches (repeatable): --route-host demo.example.com. Empty matches all hosts.
+      --route-path string               Request path the route matches (must start with '/'); defaults to the trigger URL/prefix
+      --route-annotation stringArray    Annotation added to the generated route object: --route-annotation key=value (repeatable)
+      --route-tls string                Name of the Secret holding TLS key and cert (ingress provider only; gateway TLS is configured on the Gateway listener)
+      --gateway stringArray             Parent Gateway the HTTPRoute attaches to (gateway provider): --gateway name or --gateway namespace/name (repeatable)
       --weight ints                     Weight for each function supplied with --function flag, in the same order. Used for canary deployment
       --spec                            Save to the spec directory instead of creating on cluster
       --dry                             View the generated specs

--- a/content/en/docs/reference/fission-cli/fission_httptrigger_update.md
+++ b/content/en/docs/reference/fission-cli/fission_httptrigger_update.md
@@ -18,10 +18,16 @@ fission httptrigger update [flags]
       --url string                      URL pattern (See gorilla/mux supported patterns) [DEPRECATED for 'fn create', use 'route create' instead]
       --function stringArray            Name(s) of the function for this trigger. (If 2 functions are supplied with this flag, traffic gets routed to them based on weights supplied with --weight flag.)
       --method stringArray              HTTP Methods: GET,POST,PUT,DELETE,HEAD. To mention single method: --method GET and for multiple methods --method GET --method POST. [DEPRECATED for 'fn create', use 'route create' instead] (default [GET])
-      --createingress                   Creates ingress with same URL
-      --ingressrule string              Host for Ingress rule: --ingressrule host=path (the format of host/path depends on what ingress controller you used)
-      --ingressannotation stringArray   Annotation for Ingress: --ingressannotation key=value (the format of annotation depends on what ingress controller you used)
-      --ingresstls string               Name of the Secret contains TLS key and crt for Ingress (the usability of TLS features depends on what ingress controller you used)
+      --createingress                   Creates ingress with same URL [DEPRECATED: the Kubernetes Ingress API is frozen, use --route-provider gateway instead]
+      --ingressrule string              Host for Ingress rule: --ingressrule host=path (the format of host/path depends on what ingress controller you used) [DEPRECATED: use --route-host/--route-path]
+      --ingressannotation stringArray   Annotation for Ingress: --ingressannotation key=value (the format of annotation depends on what ingress controller you used) [DEPRECATED: use --route-annotation]
+      --ingresstls string               Name of the Secret contains TLS key and crt for Ingress (the usability of TLS features depends on what ingress controller you used) [DEPRECATED: use --route-tls]
+      --route-provider string           Route provider that exposes the function externally: one of 'ingress' or 'gateway' (Gateway API HTTPRoute). When set, takes precedence over --createingress.
+      --route-host stringArray          Hostname the route matches (repeatable): --route-host demo.example.com. Empty matches all hosts.
+      --route-path string               Request path the route matches (must start with '/'); defaults to the trigger URL/prefix
+      --route-annotation stringArray    Annotation added to the generated route object: --route-annotation key=value (repeatable)
+      --route-tls string                Name of the Secret holding TLS key and cert (ingress provider only; gateway TLS is configured on the Gateway listener)
+      --gateway stringArray             Parent Gateway the HTTPRoute attaches to (gateway provider): --gateway name or --gateway namespace/name (repeatable)
       --weight ints                     Weight for each function supplied with --function flag, in the same order. Used for canary deployment
       --prefix string                   Prefix with which functions are exposed. NOTE: Prefix takes precedence over URL/RelativeURL [DEPRECATED for 'fn create', use 'route create' instead]
       --keepprefix                      Keep the prefix in the URL while forwarding request to the function

--- a/content/en/docs/reference/fission-cli/fission_package_create.md
+++ b/content/en/docs/reference/fission-cli/fission_package_create.md
@@ -22,6 +22,7 @@ fission package create [flags]
       --srcchecksum string          SHA256 checksum of source archive when providing URL
       --deploychecksum string       SHA256 checksum of deploy archive when providing URL
       --insecure                    Skip generating SHA256 checksum for file integrity validation
+      --oci string                  Pre-built OCI image reference containing the deployment code (registry/repo:tag[@digest])
       --buildcmd string             Build command for builder to run with
       --spec                        Save to the spec directory instead of creating on cluster
       --dry                         View the generated specs

--- a/content/en/docs/reference/fission-cli/fission_package_update.md
+++ b/content/en/docs/reference/fission-cli/fission_package_update.md
@@ -22,6 +22,7 @@ fission package update [flags]
       --srcchecksum string          SHA256 checksum of source archive when providing URL
       --deploychecksum string       SHA256 checksum of deploy archive when providing URL
       --insecure                    Skip generating SHA256 checksum for file integrity validation
+      --oci string                  Pre-built OCI image reference containing the deployment code (registry/repo:tag[@digest])
       --buildcmd string             Build command for builder to run with
   -f, --force                       -f |:|: Force update a package even if it is used by one or more functions
   -h, --help                        help for update

--- a/content/en/docs/releases/v1.26.0.md
+++ b/content/en/docs/releases/v1.26.0.md
@@ -3,7 +3,7 @@ title: "v1.26.0 Release Notes"
 linkTitle: v1.26.0
 weight: 67
 description: >
-  Release notes for Fission v1.26.0 — OCI-native package delivery, the Gateway API route provider, streaming responses, functions as MCP tools, and an EndpointSlice-native data plane.
+  Release notes for Fission v1.26.0 — OCI-native package delivery, the Gateway API route provider, streaming responses, and functions as MCP tools.
 ---
 
 ## Upgrade Notes

--- a/content/en/docs/releases/v1.26.0.md
+++ b/content/en/docs/releases/v1.26.0.md
@@ -1,0 +1,145 @@
+---
+title: "v1.26.0 Release Notes"
+linkTitle: v1.26.0
+weight: 67
+description: >
+  Release notes for Fission v1.26.0 — OCI-native package delivery, the Gateway API route provider, streaming responses, functions as MCP tools, and an EndpointSlice-native data plane.
+---
+
+## Upgrade Notes
+
+{{< notice warning >}}
+v1.26.0 is a large feature release and changes several runtime defaults — the router now serves warm traffic from EndpointSlices and accounts concurrency per replica, OCI package delivery becomes the cold-start path when a registry is configured, and streaming responses are no longer bound by the function timeout.
+None of these require a configuration change to keep working, but review the items below before rolling out, especially if you depend on global concurrency enforcement or on the previous Ingress route flow.
+The minimum Kubernetes version is unchanged at **1.32**.
+{{< /notice >}}
+
+For the general upgrade steps (CRDs, CLI, Helm chart), see the [Upgrade Guide](/docs/installation/upgrade/).
+The behavioral changes specific to v1.26.0 and the action each requires are below.
+
+### Router serves warm traffic from EndpointSlices; concurrency is per-replica by default
+
+The router now discovers function pod addresses natively from Kubernetes EndpointSlices instead of asking the executor on every request.
+Warm traffic no longer makes an executor RPC, so functions stay reachable even while the executor is restarting or unavailable.
+As part of this, every invoked pool-manager function gets a headless Service automatically (previously these pods were invisible to Kubernetes service discovery), and the router needs new RBAC for `endpointslices` and `services` — the chart adds it automatically.
+
+The default concurrency accounting also changes: each router replica now enforces a function's concurrency limit **locally** rather than coordinating a global count.
+On a single-replica router this is identical to before.
+On a multi-replica router the effective ceiling is the per-function limit times the replica count.
+If a function requires a strict global limit, set the annotation `fission.io/concurrency-enforcement: strict` on it to restore global enforcement.
+
+The data plane is on by default (`router.endpointSliceCache.mode: "on"`, `executor.functionServices.enabled: true`).
+A one-release escape hatch (`router.endpointSliceCache.mode: "off"`) is available if you need to fall back to executor-driven addressing.
+
+### OCI package delivery becomes the cold-start path when a registry is configured
+
+With a package registry configured (`packageRegistry.enabled: true` plus a `repositoryPrefix` and push/pull secrets), every successful build now publishes the deployment archive as a **digest-pinned OCI image**, and functions cold-start by pulling that image instead of downloading a tarball from the storage service.
+If no registry is configured, nothing changes — packages keep using tarballs through the storage service exactly as before.
+
+`fallbackToStorage` (default `true`) keeps a build succeeding by falling back to a tarball if the registry push fails; the package then carries an `OCIPublished=False` condition.
+A single package can be kept on the tarball path with the annotation `fission.io/package-delivery: tarball`.
+
+On Kubernetes 1.33+ you can additionally let the kubelet mount the code image directly as an image volume (`executor.enableOCIImageVolume`, default `true`, auto-gated to clusters that support it).
+See [OCI image packages](/docs/usage/function/oci-packages/) for the full setup, registry-credential, and compatibility detail.
+
+### Streaming responses are not bound by the function timeout
+
+Functions can opt into streaming (Server-Sent Events, HTTP chunked transfer, or a WebSocket upgrade) per function.
+A streaming response is flushed incrementally and is **not** cut off at `functionTimeout`; instead it is governed by an idle timeout (default 60s, reset on each chunk) and an optional absolute `maxDuration` ceiling.
+Existing functions are unaffected — streaming is off unless you enable it.
+See [Streaming responses](/docs/usage/function/streaming/).
+
+### Ingress route flow is deprecated in favor of the Gateway API
+
+The router can now manage a Gateway API `HTTPRoute` for an HTTPTrigger, the same way it managed an `Ingress` for `--createingress`.
+The `--createingress` / `IngressConfig` path still works but is **deprecated**, because the Kubernetes Ingress API is frozen.
+Existing Ingress-based triggers keep working after upgrade and are not auto-converted; migrate them per trigger when you are ready.
+See [Exposing functions with the Gateway API](/docs/usage/gateway-api/).
+
+### Cleanup finalizers are active by default
+
+A `fission.io/function-cleanup` finalizer (chart-wide `finalizerEnabled`, default `on`) makes the executor tear a function's workloads down before the Function object is collected, closing a long-standing cross-namespace teardown leak.
+If you ever need to force-delete a Function while the executor is down, clear its finalizers:
+
+```sh
+kubectl patch function <name> -n <ns> --type=merge -p '{"metadata":{"finalizers":[]}}'
+```
+
+### Route conflicts are now deterministic and observable
+
+The router builds its route table incrementally and resolves overlapping triggers with a deterministic precedence (host-qualified before host-less, exact path before prefix, longest prefix, then oldest trigger).
+A trigger that loses a conflict now surfaces a `RouteAdmitted=False` condition with reason `RouteConflict` instead of producing a silently nondeterministic outcome.
+If you have multiple triggers that overlap on host/path, check the `RouteAdmitted` condition after upgrading — the winning trigger may differ from the previous, list-order-dependent behavior.
+
+## Deprecations/Removals
+
+- The **Ingress route flow** (`--createingress`, `IngressConfig`) is deprecated in favor of the Gateway API route provider. It still functions; the Kubernetes Ingress API is frozen, so new triggers should use the Gateway API.
+- The **event-based WebSocket keepalive** mechanism (the fetcher `/wsevent` endpoints used by the Python `socket_tracker.py`) is deprecated in favor of the streaming WebSocket path and is targeted for removal in v1.28. The `main(ws, clients)` programming model is unchanged.
+- Minimum Kubernetes is unchanged at **1.32** (`kubeVersion: ">=1.32.0-0"`).
+
+## Highlights
+
+- **OCI-native package delivery.**
+  A package's deployment archive can be an OCI image instead of a zip archive — build a code-only image (`FROM scratch`), push it to any registry, and reference it with `fission package create --oci <ref>`.
+  When a package registry is configured, builds publish digest-pinned images automatically and functions cold-start by pulling cached layers instead of downloading and extracting a tarball, with a tarball fallback preserved.
+  On Kubernetes 1.33+ the kubelet can mount the code image directly as an image volume, removing fetch-and-extract from the cold-start path entirely.
+- **Gateway API route provider.**
+  The router manages a Gateway API `HTTPRoute` for an HTTPTrigger in attach mode — Fission creates only the route and points it at an operator-owned Gateway, so it works with any conformant implementation (Envoy Gateway, Istio, NGINX Gateway Fabric, …) with minimal RBAC.
+  New `fission route` flags (`--route-provider`, `--route-host`, `--route-path`, `--gateway`, `--route-annotation`) and a `spec.routeConfig` field configure it.
+- **Streaming responses.**
+  Functions can stream their response incrementally over Server-Sent Events, HTTP chunked transfer, or a WebSocket upgrade — for LLM token streaming, AI agent runs, chat, and other long-running responses — governed by an idle timeout rather than the function timeout.
+  WebSocket is now first-class for every environment, not just the Python GEVENT environment.
+- **Functions as Model Context Protocol (MCP) tools.**
+  A function can be advertised as an MCP tool (`fission fn create --expose-as-mcp --tool-description …`) and discovered and invoked by any LLM agent that speaks MCP, with per-namespace scoping via a signed JWT.
+  A new `fission function tools` subcommand lists the exposed tools.
+- **EndpointSlice-native data plane and a faster router hot path.**
+  The router serves warm traffic from EndpointSlices with zero executor RPCs, and a shared HTTP transport fixes connection keep-alive that never actually worked before — together cutting warm-path round-trip time substantially and raising throughput by an order of magnitude under load.
+- **Standard Kubernetes conditions on CRDs.**
+  Function, Package, HTTPTrigger, and other resources now carry standard status `conditions` (`Ready`, `BuildSucceeded`, `RouteAdmitted`, …), so `kubectl wait --for=condition=Ready function/<name>` and `fission fn get -o wide` (a `CONDITIONS` column) work, and `kubectl describe` surfaces why a resource is not ready.
+
+## Fixes
+
+- **Incremental router route updates.**
+  Canary weight changes and trigger edits no longer rebuild the entire router mux; routes are patched in place through a route table with handler indirection, and conflicts resolve deterministically.
+- **Self-healing function workloads.**
+  A Deployment or Service deleted out-of-band is now re-created by the executor proactively (targeting `MinScale`) instead of waiting for the next invocation.
+- **Runtime error-noise reduction.**
+  Pods use Kubernetes' native `sleep` preStop lifecycle action instead of `exec /bin/sleep` (which failed on shell-less distroless images), and trigger events delivered during the window between trigger creation and route reconciliation are retried instead of dropped on a transient router 404.
+- **Endpoint quarantines expire after a TTL** so a briefly-unhealthy pod address is retried rather than parked indefinitely.
+- Routine dependency and CI maintenance.
+- Helm chart published as **1.26.0**, versioned independently from the app version.
+
+## Changelog
+
+### What's Changed
+
+* test(integration): add Rust + JVM builder env tests; enable post_body/src_glob by @sanketsudake in https://github.com/fission/fission/pull/3477
+* feat(router): Gateway API route provider; deprecate Ingress by @sanketsudake in https://github.com/fission/fission/pull/3478
+* fix(security): confine fetcher file ops to shared volume via os.Root by @sanketsudake in https://github.com/fission/fission/pull/3479
+* chore(deps): bump the go-dependencies group with 2 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3480
+* chore(deps): bump the github-actions group with 2 updates by @dependabot[bot] in https://github.com/fission/fission/pull/3481
+* feat(router): RFC-0008 streaming invocation path (SSE / chunked / WebSocket) by @sanketsudake in https://github.com/fission/fission/pull/3482
+* feat(mcp): expose Fission functions as Model Context Protocol (MCP) tools by @sanketsudake in https://github.com/fission/fission/pull/3483
+* feat: OCI-native package delivery by @sanketsudake in https://github.com/fission/fission/pull/3484
+* feat: RFC-0002 EndpointSlice-native data plane (phases 0-3) by @sanketsudake in https://github.com/fission/fission/pull/3485
+* docs: publish implemented RFCs under docs/rfc; add RFC-0002 perf benchmarks by @sanketsudake in https://github.com/fission/fission/pull/3486
+* fix(router): expire endpoint quarantines after a TTL by @sanketsudake in https://github.com/fission/fission/pull/3487
+* feat: RFC-0002 phase 4 — EndpointSlice data plane on by default by @sanketsudake in https://github.com/fission/fission/pull/3488
+* chore(logging): fix three mislevelled/false-alarm control-plane logs by @sanketsudake in https://github.com/fission/fission/pull/3489
+* chore(release): prepare 1.26 by @sanketsudake in https://github.com/fission/fission/pull/3490
+* perf(router): RFC-0014 — shared transport (fix never-working keep-alive), allocation diet, resolver-cache removal by @sanketsudake in https://github.com/fission/fission/pull/3491
+* perf(router): RFC-0013 — incremental route updates (route table + handler indirection, precedence + RouteConflict conditions) by @sanketsudake in https://github.com/fission/fission/pull/3493
+* feat: RFC-0012 — OCI-native package delivery as the default (producer, B-fetcher variant, pool reaper, Path B default) by @sanketsudake in https://github.com/fission/fission/pull/3494
+
+**Full Changelog**: https://github.com/fission/fission/compare/v1.25.0...v1.26.0
+
+## References
+
+- [Upgrade Guide](/docs/installation/upgrade/)
+- [OCI image packages](/docs/usage/function/oci-packages/)
+- [Exposing functions with the Gateway API](/docs/usage/gateway-api/)
+- [Streaming responses](/docs/usage/function/streaming/)
+- [Functions as MCP tools](/docs/usage/function/mcp-tools/)
+- [Environments](/environments/)
+- [Custom Resource Definition Specification](https://doc.crds.dev/github.com/fission/fission)
+- [Releases](https://github.com/fission/fission/releases)

--- a/content/en/docs/usage/_index.en.md
+++ b/content/en/docs/usage/_index.en.md
@@ -18,6 +18,7 @@ Work through the function workflow in roughly this order:
 * [Create an environment]({{% ref "function/environments.en.md" %}}) — register a language runtime (NodeJS, Python, Go, and more) so Fission can run your code.
 * [Create a function]({{% ref "function/functions.en.md" %}}) — deploy code, add an HTTP route, and test, update, and inspect functions.
 * [Package source code]({{% ref "function/package.en.md" %}}) — build functions from source archives or ship pre-built deployment packages.
+* [OCI image packages]({{% ref "function/oci-packages.md" %}}) — ship function code as an OCI image instead of an archive, with cache-friendly cold starts.
 * [Control function execution]({{% ref "function/executor.en.md" %}}) — choose an executor (poolmgr, newdeploy, or container) and tune scaling, concurrency, and cold starts.
 * [Run a container as a function]({{% ref "function/container-functions.md" %}}) — turn any existing container image into a Fission function.
 * [Access secrets and ConfigMaps]({{% ref "function/access-secret-cfgmap-in-function.en.md" %}}) — read Kubernetes Secrets and ConfigMaps from inside a function.
@@ -26,6 +27,9 @@ Work through the function workflow in roughly this order:
 
 Operational and advanced topics:
 
+* [Stream function responses]({{% ref "function/streaming.md" %}}) — return SSE, chunked, or WebSocket responses incrementally for LLM tokens, chat, and long-running calls.
+* [Expose functions as MCP tools]({{% ref "function/mcp-tools.md" %}}) — let LLM agents discover and invoke functions over the Model Context Protocol.
+* [Expose functions with the Gateway API]({{% ref "gateway-api/_index.md" %}}) — route external traffic through a Kubernetes Gateway (the successor to Ingress).
 * [Pull from a private registry]({{% ref "function/private-registry.md" %}})
 * [Use a URL as an archive source]({{% ref "function/url-as-archive-source.md" %}})
 * [Enable Istio on Fission]({{% ref "function/enabling-istio-on-fission.md" %}})

--- a/content/en/docs/usage/function/mcp-tools.md
+++ b/content/en/docs/usage/function/mcp-tools.md
@@ -1,0 +1,110 @@
+---
+title: "Functions as MCP Tools"
+draft: false
+weight: 49
+description: >
+  Advertise a Fission function as a Model Context Protocol (MCP) tool so LLM agents can discover and invoke it — enable the MCP server, expose a function with --expose-as-mcp, describe its inputs with a JSON Schema, and scope access with a signed JWT.
+---
+
+The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open protocol that lets LLM agents discover and call external tools.
+Starting with Fission {{< release-version >}} you can advertise a function as an MCP tool: any agent that speaks MCP (for example Claude) can then list it and invoke it over Fission's existing internal invocation path, with no hand-written adapter code.
+
+Exposing a function as a tool is **opt-in per function** and additive — functions you don't mark stay private.
+
+## Enable the MCP server
+
+The MCP server is **off by default**.
+Enable it with a Helm value:
+
+```bash
+helm upgrade --install fission fission-charts/fission-all \
+  --namespace fission \
+  --set mcp.enabled=true
+```
+
+This deploys a stateless MCP server that watches `Function` resources and hot-updates its advertised tool list.
+It listens on a `ClusterIP` Service on port `8890` by default (`mcp.port`).
+
+| Helm value | Default | Meaning |
+| --- | --- | --- |
+| `mcp.enabled` | `false` | Deploy the MCP server. |
+| `mcp.port` | `8890` | Port the MCP server (and its `ClusterIP` Service) listens on. |
+| `mcp.allowInsecure` | `false` | Permit **unauthenticated** access when `authentication.enabled` is `false`. Dev/test only — every caller can then list and invoke all tool-exposed functions. |
+| `mcp.replicas` | `1` | Replica count. The server is stateless and runs without leader election; every replica serves the full tool list. |
+
+{{% notice warning %}}
+In production, leave `mcp.allowInsecure: false` and run with [authentication]({{% ref "/docs/installation/authentication.md" %}}) enabled.
+Agents then authenticate with a signed JWT whose `allowed_namespaces` claim scopes which functions they may see and call.
+{{% /notice %}}
+
+## Expose a function as a tool
+
+Create (or update) a function with `--expose-as-mcp` and a required agent-facing description:
+
+```bash
+fission fn create --name weather --env nodejs --code weather.js \
+  --expose-as-mcp \
+  --tool-description "Return the current weather for a city" \
+  --tool-input-schema weather-schema.json
+```
+
+`--tool-input-schema` points at a JSON Schema (draft 2020-12) file describing the tool's arguments; it is advertised verbatim as the MCP tool `inputSchema`.
+When omitted, the tool advertises an open object schema (`{"type":"object"}`).
+
+| Flag | Meaning |
+| --- | --- |
+| `--expose-as-mcp` | Advertise this function as an MCP tool. |
+| `--tool-description` | Agent-facing tool description (required with `--expose-as-mcp`). |
+| `--tool-input-schema` | Path to a JSON Schema file describing the tool's arguments. |
+| `--tool-name` | Override the advertised tool name (defaults to `<namespace>-<function name>`; must match `^[a-zA-Z0-9_-]{1,64}$`). |
+
+## List exposed tools
+
+```bash
+$ fission function tools
+NAME              FUNCTION   NAMESPACE   DESCRIPTION
+default-weather   weather    default     Return the current weather for a city
+```
+
+Use `-o wide`, `-o json`, or `-o yaml` for more detail.
+
+## Declarative spec
+
+Exposing a function as a tool is controlled by the presence of `spec.tool` on the `Function` resource — there is no separate `enabled` flag:
+
+```yaml
+apiVersion: fission.io/v1
+kind: Function
+metadata:
+  name: weather
+spec:
+  environment:
+    name: nodejs
+  package:
+    packageref:
+      name: weather
+  tool:
+    description: Return the current weather for a city   # required
+    # Optional JSON Schema (draft 2020-12) for the tool's arguments.
+    inputSchema:
+      type: object
+      properties:
+        city:
+          type: string
+      required: [city]
+    # Optional: override the advertised tool name (defaults to <namespace>-<name>).
+    toolName: get-weather
+```
+
+## How agents reach the tools
+
+Point an MCP-capable agent at the MCP server's endpoint (the `mcp` Service on port `8890`, exposed however you route in-cluster traffic — for example through an [HTTP trigger]({{% ref "/docs/usage/triggers/http-trigger.md" %}}) or your ingress/gateway).
+With authentication enabled, the agent presents a bearer JWT and only sees tools in its `allowed_namespaces`.
+When the agent calls a tool, the MCP server invokes the underlying function through Fission's internal invocation path and returns the response.
+
+## Related
+
+* [Create and run functions]({{% ref "functions.en.md" %}}) — the everyday function workflow.
+* [Internal Service Authentication]({{% ref "/docs/installation/internal-auth.md" %}}) — the signing used to scope agent access.
+* [Functions]({{% ref "/docs/concepts/functions.md" %}}) — the `Function` resource and the `tool` field.
+* [Custom Resource Definition Specification]({{% ref "/docs/reference/crd-reference.md" %}}) — the `ToolConfig` spec fields.

--- a/content/en/docs/usage/function/mcp-tools.md
+++ b/content/en/docs/usage/function/mcp-tools.md
@@ -3,13 +3,25 @@ title: "Functions as MCP Tools"
 draft: false
 weight: 49
 description: >
-  Advertise a Fission function as a Model Context Protocol (MCP) tool so LLM agents can discover and invoke it — enable the MCP server, expose a function with --expose-as-mcp, describe its inputs with a JSON Schema, and scope access with a signed JWT.
+  Expose a Fission function as a Model Context Protocol (MCP) tool so LLM agents can discover and invoke it, with a JSON Schema for inputs and JWT-scoped access.
 ---
 
 The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open protocol that lets LLM agents discover and call external tools.
 Starting with Fission {{< release-version >}} you can advertise a function as an MCP tool: any agent that speaks MCP (for example Claude) can then list it and invoke it over Fission's existing internal invocation path, with no hand-written adapter code.
 
 Exposing a function as a tool is **opt-in per function** and additive — functions you don't mark stay private.
+
+```mermaid
+flowchart TB
+  agent["LLM Agent"]:::user -->|"<b>1.</b> list / call tool (JWT)"| mcp["MCP Server"]:::fission
+  mcp -->|"<b>2.</b> watch Function CRDs"| fns["Tool-exposed Functions"]:::store
+  mcp -->|"<b>3.</b> invoke via internal path"| router["Router"]:::fission
+  router -->|"<b>4.</b> HTTP request"| pod["Function Pod"]:::pod
+  classDef user fill:#ffffff,stroke:#94a3b8,color:#1f2a43
+  classDef fission fill:#e8f0fe,stroke:#2d70de,color:#1f2a43
+  classDef pod fill:#e6f7f1,stroke:#11a37f,color:#1f2a43,stroke-dasharray:5 3
+  classDef store fill:#fff7e0,stroke:#dba514,color:#1f2a43,stroke-dasharray:5 3
+```
 
 ## Enable the MCP server
 

--- a/content/en/docs/usage/function/oci-packages.md
+++ b/content/en/docs/usage/function/oci-packages.md
@@ -3,7 +3,7 @@ title: "OCI image packages"
 draft: false
 weight: 36
 description: >
-  Ship function code as an OCI image instead of an archive: build a code-only image, create a package with --oci, pin digests, use private registries, and optionally mount code via Kubernetes image volumes.
+  Ship Fission function code as an OCI image instead of an archive: build a code-only image, create a package with --oci, and pin digests for fast cold starts.
 ---
 
 Starting with Fission v1.26.0, a package's deployment archive can be an **OCI image** instead of a zip archive.
@@ -15,6 +15,17 @@ $ fission package create --name hello --env python \
 ```
 
 Everything else — environments, functions, triggers, entry points — works exactly as with archive-based packages.
+
+```mermaid
+flowchart TB
+  ci["You / CI<br/>(--oci)"]:::user -->|"push code image"| reg["OCI Registry"]:::store
+  build["Fission Builder"]:::fission -->|"publish on build"| reg
+  reg -->|"pull at cold start"| pod["Function Pod"]:::pod
+  classDef user fill:#ffffff,stroke:#94a3b8,color:#1f2a43
+  classDef fission fill:#e8f0fe,stroke:#2d70de,color:#1f2a43
+  classDef pod fill:#e6f7f1,stroke:#11a37f,color:#1f2a43,stroke-dasharray:5 3
+  classDef store fill:#fff7e0,stroke:#dba514,color:#1f2a43,stroke-dasharray:5 3
+```
 
 #### Why deliver code as an image?
 

--- a/content/en/docs/usage/function/oci-packages.md
+++ b/content/en/docs/usage/function/oci-packages.md
@@ -112,16 +112,82 @@ spec:
         - name: regcred
 ```
 
-{{< notice info >}}
+{{% notice info %}}
 **Pin digests in production.**
 A package references an image; re-pushing the same tag with different content is **not** detected automatically (functions roll only on package update).
 Setting `digest` makes the reference immutable and the pull verifiable.
-{{< /notice >}}
+{{% /notice %}}
 
-#### Private and insecure registries
+#### Private registries
 
-Pulls authenticate with, in order: the `fission-fetcher` service account's `imagePullSecrets`, the package's `imagePullSecrets` (which must exist in the function's namespace), and anonymous access.
-For a cluster-wide registry credential, attach a docker-registry secret to the fetcher service account; for per-package credentials, use the spec field above.
+Code-image pulls resolve credentials in this order:
+
+1. The **`fission-fetcher` service account's `imagePullSecrets`** — the cluster-wide default for all packages.
+2. The **package's own `imagePullSecrets`** — per-package credentials, set in the package spec.
+3. **Anonymous** access.
+
+Both secret sources are resolved in the namespace the function pods run in.
+For functions in the `default` namespace that is the configured function namespace (`fission-function` in many installs); for functions in other namespaces it is the function's own namespace.
+Confirm with `kubectl get pods -l environmentName=<env> -A` if unsure.
+
+##### Step 1 — create a registry secret
+
+Create a standard `docker-registry` secret in the function-pod namespace (see the [Kubernetes guide](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for registry-specific details):
+
+```bash
+$ kubectl create secret docker-registry regcred \
+    --namespace fission-function \
+    --docker-server=registry.example.com \
+    --docker-username=ci-bot \
+    --docker-password="$REGISTRY_TOKEN"
+```
+
+##### Step 2a — cluster-wide: attach the secret to the fetcher service account
+
+Patch the `fission-fetcher` service account in the same namespace; every OCI package pull then uses it without any per-package configuration:
+
+```bash
+$ kubectl patch serviceaccount fission-fetcher \
+    --namespace fission-function \
+    -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+```
+
+##### Step 2b — per-package: reference the secret in the package spec
+
+For credentials scoped to one package (e.g. different teams pulling from different registries), set `imagePullSecrets` in the package spec instead:
+
+```yaml
+apiVersion: fission.io/v1
+kind: Package
+metadata:
+  name: hello
+spec:
+  environment:
+    name: python
+  deployment:
+    type: oci
+    oci:
+      image: registry.example.com/myteam/hello-code:v1
+      imagePullSecrets:
+        - name: regcred
+```
+
+##### Verifying
+
+Create a function on the package and invoke it; on a credential problem the function returns a 5xx and the fetcher log names the registry error:
+
+```bash
+$ kubectl logs <function-pod> -c fetcher -n fission-function | grep -i "error extracting OCI image"
+```
+
+{{% notice warning %}}
+Fission does not validate that the referenced secrets exist or hold working credentials — a missing or wrong secret surfaces only at pull time.
+With [image volumes](#optional-mount-code-with-kubernetes-image-volumes) enabled, the **kubelet** performs the pull using the same two secret sources (the pod inherits both), so the same setup keeps working — but pull errors then appear as pod events (`kubectl describe pod`, `ErrImagePull`) rather than fetcher logs.
+{{% /notice %}}
+
+Runtime/environment images are pulled by the kubelet independently of package images; for those, see [Pull an Image From a Private Registry]({{% ref "/docs/usage/function/private-registry.md" %}}).
+
+#### Insecure (plain-HTTP) registries
 
 Plain-HTTP registries are refused by default.
 To allow specific hosts (e.g. an in-cluster registry for development), set the Helm value:
@@ -132,6 +198,7 @@ fetcher:
 ```
 
 This is a comma-separated host allowlist, not a global switch — every other registry still requires TLS.
+Localhost and private (RFC-1918) IP addresses are implicitly trusted by the underlying client, matching Docker's behavior.
 
 #### Optional: mount code with Kubernetes image volumes
 

--- a/content/en/docs/usage/function/oci-packages.md
+++ b/content/en/docs/usage/function/oci-packages.md
@@ -1,0 +1,162 @@
+---
+title: "OCI image packages"
+draft: false
+weight: 36
+description: >
+  Ship function code as an OCI image instead of an archive: build a code-only image, create a package with --oci, pin digests, use private registries, and optionally mount code via Kubernetes image volumes.
+---
+
+Starting with Fission v1.26.0, a package's deployment archive can be an **OCI image** instead of a zip archive.
+You build an image whose filesystem contains your function code, push it to any OCI registry, and reference it when creating the package:
+
+```bash
+$ fission package create --name hello --env python \
+    --oci registry.example.com/myteam/hello-code:v1
+```
+
+Everything else — environments, functions, triggers, entry points — works exactly as with archive-based packages.
+
+#### Why deliver code as an image?
+
+* **Faster, cache-friendly cold starts**: nodes and registries cache image layers, so repeated fetches of the same code are cheap, and there is no zip download + extract step from Fission's internal storage.
+* **Standard supply-chain tooling**: code images can be signed (`cosign`), scanned, replicated, and promoted with the same tooling you already use for runtime images.
+* **Registry-native workflows**: CI pipelines that already push images need no extra upload step to Fission's storage service.
+
+OCI delivery is **opt-in per package**.
+Archive-based packages remain the default and are unaffected.
+
+#### Building a compatible code image
+
+The image's filesystem must contain exactly what an *extracted deployment archive* would contain — your code files at the image root (or under a sub-path, see below).
+The environment's runtime still comes from the environment image; the code image carries **only your code**.
+
+For a Python function with a `main` entry point in `hello.py`:
+
+```python
+# hello.py
+def main():
+    return "Hello, world!\n"
+```
+
+```dockerfile
+# Dockerfile
+FROM scratch
+COPY hello.py /
+```
+
+```bash
+$ docker build -t registry.example.com/myteam/hello-code:v1 .
+$ docker push registry.example.com/myteam/hello-code:v1
+```
+
+Multi-file packages work the same way — copy the whole directory:
+
+```dockerfile
+FROM scratch
+COPY src/ /
+```
+
+You can also build code images without a Docker daemon using [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane):
+
+```bash
+$ tar -cf code.tar hello.py
+$ crane append --base scratch --new_layer code.tar \
+    --new_tag registry.example.com/myteam/hello-code:v1
+```
+
+##### Base image recommendations
+
+* **Use `FROM scratch`.**
+  The code image is never executed as a container — Fission only reads its filesystem — so it needs no shell, libc, or OS layer.
+  A scratch-based code image is a few kilobytes, pulls fast, and has no CVE surface.
+* Do **not** base the code image on the environment/runtime image.
+  The runtime is supplied by the environment; duplicating it in the code image wastes pull time and storage and changes nothing at runtime.
+* If your build pipeline cannot produce `FROM scratch` images, any minimal base works — Fission extracts the *merged* filesystem, so whatever the image contains beyond your code is extracted too.
+  Keep it small and put code under a dedicated directory combined with `subPath` (below) so OS files are excluded.
+
+#### Creating packages and functions
+
+Create the package and reference it from a function as usual:
+
+```bash
+$ fission package create --name hello --env python \
+    --oci registry.example.com/myteam/hello-code:v1
+$ fission fn create --name hello --pkg hello --entrypoint hello.main
+$ fission route create --name hello --function hello --url /hello --method GET
+$ curl http://$FISSION_ROUTER/hello
+Hello, world!
+```
+
+`fission fn create --oci <ref>` is a shortcut that creates the package and the function in one step, and `fission package update --name hello --oci <ref:v2>` switches a package to a new image (followed by `fn update` to roll running functions, exactly like archive updates).
+
+The package spec exposes a few more fields than the CLI flag; use spec files for these:
+
+```yaml
+apiVersion: fission.io/v1
+kind: Package
+metadata:
+  name: hello
+spec:
+  environment:
+    name: python
+  deployment:
+    type: oci
+    oci:
+      image: registry.example.com/myteam/hello-code:v1
+      # Optional: pin the exact content; the pull fails on any mismatch.
+      digest: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+      # Optional: code lives under /app inside the image (must be a directory).
+      subPath: app
+      # Optional: registry credentials, resolved in the function namespace.
+      imagePullSecrets:
+        - name: regcred
+```
+
+{{< notice info >}}
+**Pin digests in production.**
+A package references an image; re-pushing the same tag with different content is **not** detected automatically (functions roll only on package update).
+Setting `digest` makes the reference immutable and the pull verifiable.
+{{< /notice >}}
+
+#### Private and insecure registries
+
+Pulls authenticate with, in order: the `fission-fetcher` service account's `imagePullSecrets`, the package's `imagePullSecrets` (which must exist in the function's namespace), and anonymous access.
+For a cluster-wide registry credential, attach a docker-registry secret to the fetcher service account; for per-package credentials, use the spec field above.
+
+Plain-HTTP registries are refused by default.
+To allow specific hosts (e.g. an in-cluster registry for development), set the Helm value:
+
+```yaml
+fetcher:
+  allowInsecureRegistries: "registry.dev.svc.cluster.local:5000"
+```
+
+This is a comma-separated host allowlist, not a global switch — every other registry still requires TLS.
+
+#### Optional: mount code with Kubernetes image volumes
+
+By default the per-pod fetcher pulls and extracts the image (this works on every supported Kubernetes version).
+On Kubernetes **1.33+** you can instead let the **kubelet** mount the code image directly into function pods as an [image volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/), removing the fetch-and-extract step from the cold-start path entirely:
+
+```yaml
+executor:
+  enableOCIImageVolume: true
+```
+
+On clusters below 1.33 the setting is detected as unsupported and packages silently stay on the fetcher path.
+Be aware of the behavioral differences when image volumes are active:
+
+* **The kubelet pulls the image, not Fission.**
+  Image references resolve with the node's DNS and containerd's registry configuration — a registry reachable only through cluster DNS (a ClusterIP `Service` name) will not resolve.
+  Use a registry address that nodes can reach.
+* Poolmgr functions that reference **Secrets or ConfigMaps**, and functions on **v1 environments**, automatically fall back to the fetcher path (those features need the fetcher inside the pod).
+* The code mount is **read-only**.
+  Runtimes that write next to the code (Python bytecode caches, JVM work files) should write elsewhere; the standard Fission environments handle this.
+* `subPath` must point to a **directory** inside the image (kubelets reject file sub-paths).
+* The `digest` pin is enforced by the kubelet through the volume's image reference.
+
+#### Limitations
+
+* OCI delivery applies to **deployment** archives only; source packages (built by a builder on the cluster) keep using archives.
+* The container executor is unrelated to OCI packages — it already runs your full container image and ignores packages entirely.
+* `--oci` cannot be combined with `--code`, `--src`, or `--deploy`; a package has exactly one code source.

--- a/content/en/docs/usage/function/oci-packages.md
+++ b/content/en/docs/usage/function/oci-packages.md
@@ -22,8 +22,8 @@ Everything else — environments, functions, triggers, entry points — works ex
 * **Standard supply-chain tooling**: code images can be signed (`cosign`), scanned, replicated, and promoted with the same tooling you already use for runtime images.
 * **Registry-native workflows**: CI pipelines that already push images need no extra upload step to Fission's storage service.
 
-OCI delivery is **opt-in per package**.
-Archive-based packages remain the default and are unaffected.
+OCI delivery is **opt-in**: it applies per package via `--oci`, or cluster-wide for every build once you configure a [package registry](#automatic-oci-delivery-for-built-packages).
+With neither configured, archive-based packages remain the default and are unaffected.
 
 #### Building a compatible code image
 
@@ -117,6 +117,44 @@ spec:
 A package references an image; re-pushing the same tag with different content is **not** detected automatically (functions roll only on package update).
 Setting `digest` makes the reference immutable and the pull verifiable.
 {{% /notice %}}
+
+#### Automatic OCI delivery for built packages
+
+The `--oci` flow above is **per package** — you build and push the image yourself.
+You can also have Fission do this for **every** build cluster-wide: configure a **package registry** and each successful build publishes its deployment archive as a digest-pinned OCI image, and functions cold-start by pulling it instead of downloading a tarball from the storage service.
+
+Enable it with Helm:
+
+```yaml
+packageRegistry:
+  enabled: true
+  # Repository root. Packages are pushed to <repositoryPrefix>/<namespace>/<package>.
+  repositoryPrefix: ghcr.io/myorg/fission-packages
+  # Secret names (kubernetes.io/dockerconfigjson) in the builder namespace.
+  # pushSecret needs write access (build time); pullSecret needs read access
+  # (attached to packages for the pull). Keep them separate.
+  pushSecret: registry-push
+  pullSecret: registry-pull
+  # On a failed push: true keeps the build and stores a tarball instead
+  # (the package gets condition OCIPublished=False); false fails the build.
+  fallbackToStorage: true
+```
+
+| Helm value | Default | Meaning |
+| --- | --- | --- |
+| `packageRegistry.enabled` | `false` | Publish built deployment archives as OCI images. When unset, builds use the storage-service tarball path unchanged. |
+| `packageRegistry.repositoryPrefix` | `""` | Repository root; images are pushed to `<repositoryPrefix>/<namespace>/<package>`. |
+| `packageRegistry.pushSecret` | `""` | `dockerconfigjson` secret (in the builder namespace) with **write** access, used at build time. |
+| `packageRegistry.pullSecret` | `""` | `dockerconfigjson` secret with **read** access, stamped into each package's `imagePullSecrets`. |
+| `packageRegistry.fallbackToStorage` | `true` | On push failure, keep the build and fall back to a tarball (package gets `OCIPublished=False`); `false` fails the build. |
+| `packageRegistry.publishedPrefix` | `""` | Advanced: node-visible prefix recorded in packages when nodes reach the registry at a different address than pods do (e.g. an in-cluster registry via NodePort). |
+| `packageRegistry.insecureHosts` | `""` | Comma-separated `host[:port]` list allowed to use plain HTTP instead of TLS. |
+
+To keep a single package on the tarball path regardless of the cluster setting, annotate it:
+
+```bash
+$ kubectl annotate package <name> -n <ns> fission.io/package-delivery=tarball
+```
 
 #### Private registries
 

--- a/content/en/docs/usage/function/streaming.md
+++ b/content/en/docs/usage/function/streaming.md
@@ -3,7 +3,7 @@ title: "Streaming Responses"
 draft: false
 weight: 48
 description: >
-  Stream a function's response incrementally with Server-Sent Events, HTTP chunked transfer, or a WebSocket upgrade using spec.streaming and the --streaming flags — for LLM tokens, AI agents, chat, and long-running responses.
+  Stream a Fission function's response incrementally over Server-Sent Events, HTTP chunked transfer, or WebSocket — for LLM tokens, chat, and long-running calls.
 ---
 
 By default a function buffers its full response and the router cuts the request off at `functionTimeout`.
@@ -12,6 +12,23 @@ The response is flushed to the client as it is produced and is **not** bound by 
 
 Streaming is **per-function and opt-in**: omit the `spec.streaming` object (or the `--streaming` flag) and the function keeps the existing buffered behavior exactly.
 Typical use cases are LLM token streaming, AI agent runs, chat, SSE feeds, and other long-running or bidirectional responses.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant R as Router
+    participant F as Function Pod
+    C->>R: HTTP request
+    R->>F: proxy request
+    F-->>R: first bytes
+    R-->>C: flush immediately
+    Note over R,F: idle timer resets on every chunk
+    F-->>R: more chunks
+    R-->>C: flush each chunk
+    F-->>R: stream ends
+    R-->>C: close connection
+```
 
 ## Enable streaming
 

--- a/content/en/docs/usage/function/streaming.md
+++ b/content/en/docs/usage/function/streaming.md
@@ -1,0 +1,119 @@
+---
+title: "Streaming Responses"
+draft: false
+weight: 48
+description: >
+  Stream a function's response incrementally with Server-Sent Events, HTTP chunked transfer, or a WebSocket upgrade using spec.streaming and the --streaming flags — for LLM tokens, AI agents, chat, and long-running responses.
+---
+
+By default a function buffers its full response and the router cuts the request off at `functionTimeout`.
+Starting with Fission {{< release-version >}} a function can instead **stream its response incrementally** — over Server-Sent Events (SSE), HTTP chunked transfer, or a WebSocket upgrade.
+The response is flushed to the client as it is produced and is **not** bound by `functionTimeout`.
+
+Streaming is **per-function and opt-in**: omit the `spec.streaming` object (or the `--streaming` flag) and the function keeps the existing buffered behavior exactly.
+Typical use cases are LLM token streaming, AI agent runs, chat, SSE feeds, and other long-running or bidirectional responses.
+
+## Enable streaming
+
+Create the function with `--streaming`, add a route, and invoke it:
+
+```bash
+fission fn create --name chat --env nodejs --code chat.js --streaming
+fission route create --name chat --function chat --url /chat --method POST
+```
+
+Toggle streaming back off on an existing function:
+
+```bash
+fission fn update --name chat --streaming=false
+```
+
+### CLI flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--streaming` | off | Enable streaming responses for the function. Disable on update with `--streaming=false`. |
+| `--streamingprotocol` | `auto` | Streaming protocol: `auto`, `sse`, `chunked`, or `websocket`. `auto` covers all cases; `websocket` signals intent (the upgrade is detected from the request). |
+| `--streamingidletimeout` | `60` | Abort the stream if no bytes flow from the function for this many seconds; reset on each chunk. Also bounds time-to-first-byte. |
+| `--streamingmaxduration` | `0` | Hard ceiling (seconds) on total stream lifetime; `0` means no ceiling. |
+
+## How streaming changes timeouts
+
+{{% notice info %}}
+A streaming function does **not** inherit `functionTimeout` as a wall-clock cap — that limit is exactly what streaming exists to escape.
+Progress is governed by the **idle timeout** (default 60s, reset on every chunk), and `--streamingmaxduration` is the optional absolute ceiling.
+A function that keeps producing output completes even if it runs far past `functionTimeout`.
+See the [function timeout concept]({{% ref "/docs/concepts/functions.md" %}}) for how this relates to the buffered path.
+{{% /notice %}}
+
+## Protocols
+
+`auto` (the default) handles every case; set a specific protocol only to signal intent.
+Streaming works on both the public HTTPTrigger route and the internal `/fission-function/<ns>/<name>` invocation path.
+
+{{< tabs >}}
+{{< tab "SSE" >}}
+With SSE the function writes `text/event-stream` chunks and the router flushes each one as it arrives.
+Use `curl -N` to watch tokens arrive incrementally instead of all at once:
+
+```bash
+curl -N https://<router>/chat -d '{"prompt":"hello"}'
+```
+{{< /tab >}}
+{{< tab "Chunked" >}}
+With HTTP chunked transfer the function writes its body in pieces and the router forwards each chunk without buffering the whole response.
+This is the default transport for a non-SSE, non-WebSocket streaming response and needs no client opt-in beyond reading the body as it streams.
+{{< /tab >}}
+{{< tab "WebSocket" >}}
+Create the function with the `websocket` protocol and connect with any WebSocket client:
+
+```bash
+fission fn create --name ws --env nodejs --code ws.js --streaming --streamingprotocol websocket
+fission route create --name ws --function ws --url /ws --method GET
+wscat -c ws://<router>/ws
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+## WebSocket
+
+WebSocket is now first-class for **every** environment, not just the Python GEVENT environment.
+The router upgrades the connection and holds the function pod for the socket's whole lifetime (a router-driven keepalive), and the `main(ws, clients)` programming model is unchanged.
+
+{{% notice warning %}}
+The legacy Python `socket_tracker.py` keepalive mechanism still works but is **deprecated in favor of the streaming approach** and is targeted for removal in a future release.
+New environment images should drop calls to the fetcher `/wsevent` endpoints and rely on the streaming WebSocket path.
+{{% /notice %}}
+
+For a worked WebSocket example, see the [WebSocket sample blog post](/blog/fission-websocket-sample/).
+
+## Declarative spec
+
+You can enable streaming directly on the `Function` resource:
+
+```yaml
+apiVersion: fission.io/v1
+kind: Function
+metadata:
+  name: chat
+spec:
+  environment:
+    name: nodejs
+  streaming:
+    protocol: sse
+    idleTimeoutSeconds: 60
+    maxDurationSeconds: 0     # optional absolute ceiling; 0 = unlimited
+```
+
+## Cluster default
+
+The optional router environment variable `ROUTER_STREAM_IDLE_TIMEOUT` sets the cluster-wide default idle window, which per-function `idleTimeoutSeconds` overrides.
+It is a router (Helm) setting; see [Customizing the chart](/docs/installation/upgrade/#configuration).
+
+## Related
+
+* [Create and run functions]({{% ref "functions.en.md" %}}) — the everyday function workflow.
+* [Controlling Function Execution]({{% ref "executor.en.md" %}}) — executors, scaling, and concurrency.
+* [HTTP Triggers]({{% ref "/docs/usage/triggers/http-trigger.md" %}}) — routing requests to a function.
+* [Functions]({{% ref "/docs/concepts/functions.md" %}}) — the `Function` resource and the function timeout.
+* [Custom Resource Definition Specification]({{% ref "/docs/reference/crd-reference.md" %}}) — the `streaming` spec fields.

--- a/content/en/docs/usage/gateway-api/_index.md
+++ b/content/en/docs/usage/gateway-api/_index.md
@@ -1,0 +1,354 @@
+---
+title: "Exposing Functions With the Gateway API"
+linkTitle: Gateway API
+draft: false
+weight: 59
+description: >
+  Expose a Fission function outside the cluster through the Kubernetes Gateway API by attaching a generated HTTPRoute to an operator-managed Gateway (Envoy Gateway, Istio, NGINX Gateway Fabric, …). The successor to the deprecated `--createingress` flow.
+---
+
+The [Gateway API](https://gateway-api.sigs.k8s.io/) is the successor to the (now frozen) Kubernetes Ingress API.
+Fission's router can manage a Gateway API `HTTPRoute` for an HTTPTrigger, tied to the trigger's lifecycle, the same way it managed an `Ingress` for `--createingress`.
+
+Fission runs in **attach mode**: it creates only the `HTTPRoute` and points it at a `Gateway` that the cluster operator owns.
+Fission never creates or owns the `Gateway` or `GatewayClass`, so it works with any conformant Gateway API implementation and keeps its RBAC minimal.
+
+{{% alert title="Availability" color="info" %}}
+The Gateway API route provider is available starting with **Fission v1.26.0** (unreleased at the time of writing).
+{{% /alert %}}
+
+{{% alert title="Ingress is deprecated" color="warning" %}}
+The `--createingress` / `IngressConfig` path still works but is deprecated, because the Kubernetes Ingress API is frozen.
+Prefer the Gateway API for new triggers.
+See [Migrating from Ingress](#migrating-from-ingress) below.
+{{% /alert %}}
+
+## How it works
+
+When an HTTPTrigger sets `routeConfig.provider: gateway`, the router:
+
+- Creates an `HTTPRoute` named after the trigger, in the **router's own namespace** (`fission` by default).
+- Sets the route's `parentRefs` to the Gateway(s) you specify (or a cluster-wide default Gateway).
+- Sets the route's `hostnames` and a `PathPrefix` match from your config.
+- Points the route's backend at the `router` Service on port 80 — the same backend the Ingress path used.
+- Labels the route with `triggerName`, `functionName`, and `triggerNamespace` so you can find it with `kubectl get httproute -l triggerName=<name> -n fission`.
+
+The route is reconciled level-based: it is created when missing, updated when the trigger changes, and deleted when the trigger is deleted or switched to a different provider.
+
+## Prerequisites
+
+1. A Kubernetes cluster with Fission installed (see the [installation page]({{% ref "../../installation/" %}})).
+2. The Gateway API CRDs and a Gateway controller installed in the cluster (see [Choosing a Gateway implementation](#choosing-a-gateway-implementation)).
+3. A `Gateway` resource for the router to attach routes to, with a listener that **allows routes from Fission's namespace**.
+
+## Enable the Gateway API provider in Fission
+
+The gateway route provider is **off by default**.
+Enable it (and grant the router the `gateway.networking.k8s.io` RBAC it needs) with a Helm value:
+
+```bash
+helm upgrade --install fission fission-charts/fission-all \
+  --namespace fission \
+  --set gatewayAPI.enabled=true
+```
+
+Optionally configure a **default Gateway** that triggers attach to when they don't name their own.
+The value is `name` or `namespace/name`:
+
+```bash
+  --set gatewayAPI.defaultParentRef=fission-gateways/shared-gw
+```
+
+When `gatewayAPI.enabled=true`, the chart adds RBAC for the router to manage `httproutes` (and read `referencegrants`).
+If you request the `gateway` provider on a trigger while this is disabled, the router logs a warning and creates no route.
+
+## Create a Gateway for Fission to attach to
+
+The operator owns the `Gateway`.
+Its listener must allow `HTTPRoute`s from the namespace Fission creates routes in (`fission` by default).
+A minimal HTTP Gateway that accepts routes from any namespace:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: fission-gw
+  namespace: fission
+spec:
+  gatewayClassName: eg          # the GatewayClass of your implementation
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same            # routes in the Gateway's own namespace; use `All` for cross-namespace
+```
+
+{{% alert title="Cross-namespace attachment" color="info" %}}
+Whether an `HTTPRoute` in the `fission` namespace may attach to a `Gateway` in another namespace is controlled by the **Gateway listener's `allowedRoutes.namespaces`** (`Same`, `All`, or a label `Selector`) — not by a `ReferenceGrant`.
+No `ReferenceGrant` is needed for the route's backend, because Fission's generated `HTTPRoute` and its backend (the `router` Service) always live in the same namespace.
+{{% /alert %}}
+
+## Expose a function
+
+Create the function and route, selecting the gateway provider and the Gateway to attach to:
+
+```bash
+fission env create --name nodejs --image ghcr.io/fission/node-env
+fission function create --name hello --env nodejs --code hello.js
+
+fission route create --name hello \
+  --function hello \
+  --method GET \
+  --url /hello \
+  --route-provider gateway \
+  --route-host demo.example.com \
+  --gateway fission-gw
+```
+
+Verify the route was created and accepted by the Gateway:
+
+```bash
+$ kubectl get httproute -n fission -l triggerName=hello
+NAME    HOSTNAMES                 AGE
+hello   ["demo.example.com"]      5s
+
+$ kubectl get httproute hello -n fission -o jsonpath='{.status.parents[0].conditions}'
+# look for type=Accepted, status=True and type=ResolvedRefs, status=True
+```
+
+Then call the function through the Gateway's address (the Gateway controller provisions a Service / load balancer; consult your implementation for how to obtain it):
+
+```bash
+$ curl -H "Host: demo.example.com" http://<gateway-address>/hello
+```
+
+### CLI flags
+
+| Flag | Description |
+|------|-------------|
+| `--route-provider` | `gateway` or `ingress`. Selects the route provider. Takes precedence over `--createingress`. |
+| `--route-host` | Hostname the route matches. Repeatable. Empty matches all hosts. |
+| `--route-path` | Request path to match (absolute, starts with `/`). Defaults to the trigger URL/prefix. |
+| `--gateway` | Parent Gateway to attach to: `name` or `namespace/name`. **Repeatable** — attach to several Gateways at once. |
+| `--route-annotation` | `key=value` annotation added to the generated `HTTPRoute`. Repeatable. `-` clears all. |
+| `--route-tls` | TLS Secret name. **Ingress provider only** — for the gateway provider, configure TLS on the Gateway listener instead. |
+
+`fission route update` merges these flags into the trigger's existing `routeConfig`, so you can change one field (for example `--route-host`) without re-specifying the rest.
+
+## RouteConfig reference (spec)
+
+`--route-*` flags populate `spec.routeConfig` on the HTTPTrigger.
+You can also write it directly in a spec file:
+
+```yaml
+apiVersion: fission.io/v1
+kind: HTTPTrigger
+metadata:
+  name: hello
+spec:
+  functionref:
+    type: name
+    name: hello
+  methods:
+    - GET
+  relativeurl: /hello
+  routeConfig:
+    provider: gateway              # "gateway" | "ingress"
+    hostnames:
+      - demo.example.com           # omit / "*" to match all hosts
+    path: /hello                   # PathPrefix match; defaults to "/"
+    annotations:                   # added to the generated HTTPRoute
+      example.com/team: payments
+    gateway:
+      parentRefs:                  # the Gateway(s) to attach to
+        - name: fission-gw
+          namespace: fission       # optional; defaults to the router's namespace
+          sectionName: http        # optional; attach to a specific listener
+          port: 80                 # optional; narrow attachment to a listener port
+```
+
+Notes:
+
+- `provider` is required.
+  When it is `gateway`, you must supply at least one `parentRef` **unless** the router is configured with a default Gateway (`gatewayAPI.defaultParentRef`).
+- `tls` applies only to the ingress provider and is rejected by validation when `provider: gateway` (gateway TLS lives on the Gateway listener).
+- `routeConfig` takes precedence over the deprecated `createingress` + `ingressconfig` fields.
+
+## Using more than one Gateway / implementation
+
+Because Fission only attaches `HTTPRoute`s, **each trigger chooses its own Gateway(s)** via `parentRefs`.
+Different triggers can attach to different Gateways — backed by different `GatewayClass`es and even different implementations — at the same time:
+
+```bash
+# Trigger A → an Envoy Gateway in the "edge" namespace
+fission route create --name public-api --function api --url /api \
+  --route-provider gateway --gateway edge/envoy-gw --route-host api.example.com
+
+# Trigger B → an internal Istio gateway
+fission route create --name internal --function worker --url /internal \
+  --route-provider gateway --gateway mesh/istio-gw --route-host internal.svc.local
+```
+
+A single trigger can also attach to **multiple** Gateways by repeating `--gateway`.
+
+## Choosing a Gateway implementation
+
+Any [conformant Gateway API implementation](https://gateway-api.sigs.k8s.io/implementations/) works.
+Below are quick-starts for three popular ones.
+In each case: install the controller, create a `GatewayClass` (most installs ship one) and a `Gateway`, then point your Fission route at that Gateway with `--gateway`.
+
+### Envoy Gateway
+
+[Envoy Gateway](https://gateway.envoyproxy.io/) is a standalone Gateway API implementation built on Envoy.
+
+```bash
+helm install envoy-gateway oci://docker.io/envoyproxy/gateway-helm \
+  --version v1.8.1 -n envoy-gateway-system --create-namespace --wait
+
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: fission-gw
+  namespace: fission
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+EOF
+
+fission route create --name hello --function hello --url /hello \
+  --route-provider gateway --gateway fission-gw --route-host demo.example.com
+```
+
+### Istio
+
+[Istio](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/) supports the Gateway API natively for ingress.
+With Istio installed, its `GatewayClass` (`istio`) is available; just create a `Gateway` and Fission route.
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: fission-gw
+  namespace: fission
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+EOF
+
+fission route create --name hello --function hello --url /hello \
+  --route-provider gateway --gateway fission-gw --route-host demo.example.com
+```
+
+Istio provisions a gateway Deployment + Service for the `Gateway`; use that Service's address to reach the function.
+
+### NGINX Gateway Fabric
+
+[NGINX Gateway Fabric](https://docs.nginx.com/nginx-gateway-fabric/) is the Gateway API implementation backed by NGINX, and a natural migration target for users coming from `ingress-nginx`.
+
+```bash
+helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
+  --create-namespace -n nginx-gateway
+
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: fission-gw
+  namespace: fission
+spec:
+  gatewayClassName: nginx
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+EOF
+
+fission route create --name hello --function hello --url /hello \
+  --route-provider gateway --gateway fission-gw --route-host demo.example.com
+```
+
+## Migrating from Ingress
+
+Existing HTTPTriggers created with `--createingress` keep working unchanged after an upgrade.
+Fission does **not** auto-convert them to the Gateway API, because doing so would break clusters that have no Gateway API installed.
+Migration is opt-in and can be done per trigger, with no downtime for the others.
+
+### Map the old flags to the new ones
+
+| Ingress flag (deprecated) | Gateway equivalent |
+|---------------------------|--------------------|
+| `--createingress` | `--route-provider gateway` |
+| `--ingressrule host=path` | `--route-host host` + `--route-path path` |
+| `--ingressannotation k=v` | `--route-annotation k=v` |
+| `--ingresstls secret` | configured on the Gateway listener (not on the route) |
+
+### Migrate a trigger in place
+
+Point an existing trigger at a Gateway; the router deletes the old `Ingress` and creates the `HTTPRoute` in the same reconcile:
+
+```bash
+fission route update --name hello \
+  --function hello \
+  --url /hello \
+  --route-provider gateway \
+  --route-host demo.example.com \
+  --gateway fission-gw
+```
+
+Confirm the switch:
+
+```bash
+kubectl get ingress  -n fission -l triggerName=hello   # should be gone
+kubectl get httproute -n fission -l triggerName=hello   # should exist and be Accepted
+```
+
+To roll back, run the same `update` with `--route-provider ingress` (or remove `routeConfig` and keep `--createingress`).
+
+### Suggested rollout
+
+1. Install a Gateway controller and create a `Gateway` whose listener allows routes from the `fission` namespace.
+2. `helm upgrade --set gatewayAPI.enabled=true`.
+3. Migrate one non-critical trigger, verify it serves through the Gateway, then migrate the rest.
+4. Decommission the old Ingress controller once no triggers use `--createingress`.
+
+## Troubleshooting
+
+- **No `HTTPRoute` is created.**
+  Confirm `gatewayAPI.enabled=true` (the router logs a warning when a trigger requests the gateway provider while it is disabled), and that the Gateway API CRDs are installed.
+- **`HTTPRoute` exists but is not `Accepted`.**
+  Check the Gateway listener's `allowedRoutes.namespaces` permits the `fission` namespace, that the `parentRef` name/namespace match the Gateway, and that the hostname/port are compatible with a listener.
+  Inspect `kubectl get httproute <name> -n fission -o yaml` under `.status.parents[].conditions`.
+- **Function not reachable through the Gateway.**
+  Ensure the `Gateway` is `Programmed` and has an address, and that you send the request with the matching `Host` header.
+
+## See also
+
+- [HTTP Triggers]({{% ref "../triggers/http-trigger.md" %}})
+- [Exposing Functions With Ingress]({{% ref "../ingress/" %}}) (deprecated)
+- [Gateway API documentation](https://gateway-api.sigs.k8s.io/)

--- a/content/en/docs/usage/gateway-api/_index.md
+++ b/content/en/docs/usage/gateway-api/_index.md
@@ -4,7 +4,7 @@ linkTitle: Gateway API
 draft: false
 weight: 59
 description: >
-  Expose a Fission function outside the cluster through the Kubernetes Gateway API by attaching a generated HTTPRoute to an operator-managed Gateway (Envoy Gateway, Istio, NGINX Gateway Fabric, …). The successor to the deprecated `--createingress` flow.
+  Expose a Fission function through the Kubernetes Gateway API by attaching a generated HTTPRoute to an operator-managed Gateway — the successor to Ingress.
 ---
 
 The [Gateway API](https://gateway-api.sigs.k8s.io/) is the successor to the (now frozen) Kubernetes Ingress API.
@@ -24,6 +24,20 @@ See [Migrating from Ingress](#migrating-from-ingress) below.
 {{% /alert %}}
 
 ## How it works
+
+```mermaid
+flowchart TB
+  trig["HTTPTrigger<br/>routeConfig: gateway"]:::store -->|"<b>1.</b> router reconciles"| router["Fission Router"]:::fission
+  router -->|"<b>2.</b> creates HTTPRoute"| route["HTTPRoute"]:::store
+  route -->|"<b>3.</b> attaches to"| gw["Gateway<br/>(operator-owned)"]:::user
+  client["External Client"]:::user -->|"<b>4.</b> request"| gw
+  gw -->|"<b>5.</b> routes to"| router
+  router -->|"<b>6.</b> proxies to"| pod["Function Pod"]:::pod
+  classDef user fill:#ffffff,stroke:#94a3b8,color:#1f2a43
+  classDef fission fill:#e8f0fe,stroke:#2d70de,color:#1f2a43
+  classDef pod fill:#e6f7f1,stroke:#11a37f,color:#1f2a43,stroke-dasharray:5 3
+  classDef store fill:#fff7e0,stroke:#dba514,color:#1f2a43,stroke-dasharray:5 3
+```
 
 When an HTTPTrigger sets `routeConfig.provider: gateway`, the router:
 

--- a/content/en/docs/usage/ingress/_index.md
+++ b/content/en/docs/usage/ingress/_index.md
@@ -7,6 +7,12 @@ description: >
   Expose a Fission function outside the cluster on an FQDN using an NGINX ingress controller and Fission's route with --createingress.
 ---
 
+{{% alert title="Deprecated — use the Gateway API" color="warning" %}}
+The Kubernetes Ingress API is frozen, and Fission's `--createingress` flow is **deprecated**.
+For new functions, prefer [Exposing Functions With the Gateway API]({{% ref "../gateway-api/" %}}) — its official successor — available since **Fission v1.26.0**.
+The Ingress flow documented below keeps working for the deprecation window; see [Migrating from Ingress]({{% ref "../gateway-api/_index.md#migrating-from-ingress" %}}) when you are ready to switch.
+{{% /alert %}}
+
 Ingress is a Kubernetes built-in resource that allows accessing Kubernetes services from outside of cluster with help of a ingress controller.
 There are many ingress controllers available to use [webpage](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#additional-controllers).
 


### PR DESCRIPTION
Prepares the site for the Fission **v1.26.0** release (currently a draft on the product repo).

## Headline features
- **OCI-native package delivery** — the OCI image-packages guide (from #296), plus cluster-wide automatic delivery (`packageRegistry.*`), and cross-cutting updates to the packages and storagesvc docs.
- **Gateway API route provider** — the Gateway API usage guide and Ingress deprecation notice (from #294).
- **Streaming responses** — new `docs/usage/function/streaming.md` (SSE / chunked / WebSocket), governed by an idle timeout instead of `functionTimeout`.
- **Functions as MCP tools** — new `docs/usage/function/mcp-tools.md` (enable the MCP server, `--expose-as-mcp`, `fission function tools`, `spec.tool`, JWT scoping).

## Release mechanics
- `config.toml`: `release_version` → `v1.26.0`, `chart_version` → `1.26.0`.
- New release-notes page `docs/releases/v1.26.0.md` (weight 67) with authored Upgrade Notes (EndpointSlice data-plane concurrency default, OCI default-on, streaming/timeout, Gateway/Ingress deprecation, finalizers, deterministic route precedence), Highlights, Fixes, and the verbatim changelog.
- Upgrade guide gains a `1.26.x` section; the prior section is pinned to literal `v1.25.0`.
- Compatibility matrix gains a literal `v1.25.0` row (the shortcode top row already carries 1.26's data).
- Homepage What's New card + `concepts/functions.md` (streaming/tool fields, conditions); WebSocket blog now points to the streaming guide.
- Regenerated CLI/CRD reference docs (`--streaming*`, `--oci`, `--expose-as-mcp`/`--tool-*`, route-provider flags; `OCIArchive`/`StreamingConfig`/`ToolConfig`/`GatewayRouteConfig` types).

## Folds in
- #294 (Gateway API usage guide)
- #296 (OCI image packages guide)

Verified with `./build.sh` (pinned Hugo 0.157.0): clean build, 539 pages, no path/ref warnings; new pages render and the `upgrade-to-126x-release` anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)