### PR TITLE
Add CI/CD and GitOps guide (highlighting OCI delivery)

### DIFF
--- a/content/en/blog/fission_github_action.md
+++ b/content/en/blog/fission_github_action.md
@@ -9,6 +9,10 @@ type = "blog"
 
 # Introduction
 
+> **Note (2026):** This post uses the original `.github/main.workflow` syntax, which GitHub has since replaced with YAML workflow files.
+> For the current way to deploy Fission from CI/CD — including registry-native [OCI image packages](https://fission.io/docs/usage/function/oci-packages/) — see [CI/CD and GitOps with Fission](https://fission.io/docs/usage/cicd/).
+> The concepts below still apply; only the workflow syntax has changed.
+
 GitHub recently launched [GitHub Actions](https://github.com/features/actions) which enable developers to develop workflows and execute them based on events in code repositories such as a push event or an issue creation. 
 
 There are many Actions available on the [Github marketplace](https://github.com/marketplace?type=actions) which you can use for automating various tasks and workflows around development and deployment. In this tutorial we will use the recently launched [Fission Action](https://github.com/marketplace/actions/fission) and build a simple workflow that deploys a Fission function to a Kubernetes cluster.

--- a/content/en/docs/usage/_index.en.md
+++ b/content/en/docs/usage/_index.en.md
@@ -34,4 +34,4 @@ Operational and advanced topics:
 * [Use a URL as an archive source]({{% ref "function/url-as-archive-source.md" %}})
 * [Enable Istio on Fission]({{% ref "function/enabling-istio-on-fission.md" %}})
 
-For reproducible, version-controlled deployments, also read about the [spec-based workflow]({{% ref "/docs/usage/spec/_index.md" %}}).
+For reproducible, version-controlled deployments, also read about the [spec-based workflow]({{% ref "/docs/usage/spec/_index.md" %}}) and how to [deploy from CI/CD]({{% ref "cicd.md" %}}).

--- a/content/en/docs/usage/cicd.md
+++ b/content/en/docs/usage/cicd.md
@@ -13,7 +13,7 @@ It builds on two pieces that work together:
 - **Declarative [YAML specs]({{% ref "spec/_index.md" %}})** — your functions, environments, and triggers as version-controlled YAML, reconciled onto the cluster with one idempotent command. This is the CI/CD *control plane*.
 - **[OCI image packages]({{% ref "function/oci-packages.md" %}})** — ship function code as a digest-pinned container image your pipeline already knows how to build, push, sign, and scan. This makes the deployed *artifact* registry-native.
 
-Use specs alone to deploy from source, or add OCI delivery for an immutable, promote-by-digest GitOps flow.
+Use specs alone to deploy from source, or add OCI delivery for an immutable, promote-by-digest GitOps flow — and because an OCI package carries no archive to upload, you can apply it with the Fission CLI, plain `kubectl`, or Argo CD / Flux.
 
 ## The foundation: `fission spec apply`
 
@@ -149,6 +149,75 @@ Delivering code as an image gives the pipeline:
 {{% notice tip %}}
 Prefer the cluster to publish images for you?
 Set `packageRegistry.enabled` (see [OCI image packages]({{% ref "function/oci-packages.md" %}}#automatic-oci-delivery-for-built-packages)) and every on-cluster build publishes a digest-pinned image automatically — your pipeline keeps running `fission spec apply` and gets registry-native delivery without building images itself.
+{{% /notice %}}
+
+### Apply with `kubectl` — no Fission CLI required
+
+`fission spec apply` exists mainly to do one thing the Kubernetes API cannot: package your local source, upload it to the cluster's storage service, and rewrite the spec's `archive://` URLs into real ones.
+An OCI package has **no archive to upload** — its code already lives in a registry — so the `Package` and `Function` are ordinary Kubernetes custom resources.
+That means you can manage them with `kubectl apply` (or Argo CD / Flux) directly, with **no Fission CLI in the pipeline at all**:
+
+```yaml
+# fission-app.yaml
+apiVersion: fission.io/v1
+kind: Environment
+metadata:
+  name: nodejs
+spec:
+  version: 3
+  runtime:
+    image: ghcr.io/fission/node-env
+---
+apiVersion: fission.io/v1
+kind: Package
+metadata:
+  name: hello
+spec:
+  environment:
+    name: nodejs
+  deployment:
+    type: oci
+    oci:
+      image: ghcr.io/myorg/hello-code
+      digest: sha256:<digest>          # pin to the image your pipeline pushed
+---
+apiVersion: fission.io/v1
+kind: Function
+metadata:
+  name: hello
+spec:
+  environment:
+    name: nodejs
+  package:
+    packageref:
+      name: hello
+    # functionName: <entrypoint>       # optional, e.g. "hello.main"
+---
+apiVersion: fission.io/v1
+kind: HTTPTrigger
+metadata:
+  name: hello
+spec:
+  functionref:
+    type: name
+    name: hello
+  methods: [GET]
+  relativeurl: /hello
+```
+
+The deploy step is then just `kubectl`:
+
+```bash
+kubectl apply -f fission-app.yaml
+kubectl wait --for=condition=Ready function/hello
+```
+
+This works because {{< release-version >}} validates these resources with API-server CEL and ships server-side-apply markers, so `kubectl apply --server-side`, `--dry-run=server`, Argo CD, and Flux reconcile Fission resources like any other manifest, and `kubectl wait --for=condition=Ready` blocks until the function is live.
+Two prerequisites: install the CRDs once (`kubectl create -k "github.com/fission/fission/crds/v1?ref={{% release-version %}}"`), and keep the environment, package, and function in the same namespace.
+
+{{% notice info %}}
+This is OCI-only.
+A source or pre-built-archive package still needs `fission spec apply` (or `fission package create`) to upload the archive — `kubectl` cannot perform that upload.
 {{% /notice %}}
 
 ## Promote across environments by digest

--- a/content/en/docs/usage/cicd.md
+++ b/content/en/docs/usage/cicd.md
@@ -1,0 +1,176 @@
+---
+title: "CI/CD and GitOps"
+linkTitle: "CI/CD and GitOps"
+draft: false
+weight: 35
+description: >
+  Automate Fission function deployment from CI/CD with declarative `fission spec apply`, a GitHub Actions pipeline, and registry-native OCI image delivery.
+---
+
+This guide shows how to deploy Fission functions from a CI/CD pipeline instead of by hand.
+It builds on two pieces that work together:
+
+- **Declarative [YAML specs]({{% ref "spec/_index.md" %}})** — your functions, environments, and triggers as version-controlled YAML, reconciled onto the cluster with one idempotent command. This is the CI/CD *control plane*.
+- **[OCI image packages]({{% ref "function/oci-packages.md" %}})** — ship function code as a digest-pinned container image your pipeline already knows how to build, push, sign, and scan. This makes the deployed *artifact* registry-native.
+
+Use specs alone to deploy from source, or add OCI delivery for an immutable, promote-by-digest GitOps flow.
+
+## The foundation: `fission spec apply`
+
+A CI/CD pipeline for Fission is, at its core, a job that runs `fission spec apply` against your cluster.
+Because apply is **idempotent** — it reconciles the cluster to match the committed specs (creating, updating, and pruning) — the same job is safe to run on every push.
+
+```bash
+fission spec apply --wait   # block until builds finish; exits non-zero on failure
+```
+
+Keep the `specs/` directory in version control next to your code, and generate resources with `--spec` (for example `fission function create --spec ...`) so every change is reviewable in a pull request.
+See [YAML Specs]({{% ref "spec/_index.md" %}}) for the full spec workflow.
+
+## Deploy from GitHub Actions
+
+A minimal pipeline installs the Fission CLI, points it at your cluster with a `KUBECONFIG` secret, and applies the specs on every push to `main`:
+
+```yaml
+name: Deploy to Fission
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the Fission CLI
+        run: |
+          curl -Lo fission https://github.com/fission/fission/releases/download/{{% release-version %}}/fission-{{% release-version %}}-linux-amd64
+          chmod +x fission && sudo mv fission /usr/local/bin/
+
+      - name: Configure cluster access
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Apply specs
+        run: fission spec apply --wait
+```
+
+Store a base64-encoded kubeconfig — ideally for a dedicated, least-privilege ServiceAccount — as the `KUBECONFIG` repository secret.
+The same shape works on any CI system: install the CLI, provide cluster credentials, run `fission spec apply`.
+
+{{% notice info %}}
+This supersedes the older `.github/main.workflow` approach from the [2019 Fission GitHub Action post](/blog/new-fission-github-action-easily-automate-your-ci/cd-workflows/) — GitHub has since replaced that syntax with the YAML workflows shown here.
+{{% /notice %}}
+
+## Registry-native CI/CD with OCI packages
+
+The pipeline above uploads your **source** to the cluster and builds it there.
+With [OCI image packages]({{% ref "function/oci-packages.md" %}}), your pipeline instead builds a small **code image**, pushes it to a registry it already uses, and the package references that image **by digest** — no separate upload step, and a deploy that is immutable and verifiable.
+
+```mermaid
+flowchart TB
+  ci["CI pipeline"]:::user -->|"<b>1.</b> build + push code image"| reg["OCI Registry"]:::store
+  ci -->|"<b>2.</b> deploy by digest"| fission["Fission"]:::fission
+  fission -->|"<b>3.</b> roll function"| pod["Function Pod"]:::pod
+  reg -->|"<b>4.</b> pull image at cold start"| pod
+  classDef user fill:#ffffff,stroke:#94a3b8,color:#1f2a43
+  classDef fission fill:#e8f0fe,stroke:#2d70de,color:#1f2a43
+  classDef pod fill:#e6f7f1,stroke:#11a37f,color:#1f2a43,stroke-dasharray:5 3
+  classDef store fill:#fff7e0,stroke:#dba514,color:#1f2a43,stroke-dasharray:5 3
+```
+
+A code image is just your function files on top of `scratch`:
+
+```dockerfile
+# Dockerfile
+FROM scratch
+COPY hello.js /
+```
+
+The workflow builds and pushes that image, then deploys the package **pinned to the pushed digest**:
+
+```yaml
+name: Build and deploy (OCI)
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the code image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}/hello-code:${{ github.sha }}
+
+      - name: Install the Fission CLI
+        run: |
+          curl -Lo fission https://github.com/fission/fission/releases/download/{{% release-version %}}/fission-{{% release-version %}}-linux-amd64
+          chmod +x fission && sudo mv fission /usr/local/bin/
+
+      - name: Configure cluster access
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+
+      - name: Deploy the pinned image
+        run: |
+          fission package update --name hello \
+            --oci "ghcr.io/${{ github.repository }}/hello-code@${{ steps.push.outputs.digest }}"
+          fission fn update --name hello --pkg hello
+```
+
+`docker/build-push-action` exposes the pushed image's digest as `steps.push.outputs.digest`, so the function rolls to the exact bytes the pipeline built.
+For a fully declarative flow, write that digest into the package spec's `deployment.oci.digest` field and `fission spec apply` instead — the spec stays the single source of truth.
+
+Delivering code as an image gives the pipeline:
+
+- **No upload-and-build round trip** — the registry your CI already pushes to is the delivery mechanism; cold starts pull cached layers.
+- **Supply-chain tooling for free** — sign the code image with `cosign`, scan it, and apply the same registry policies you use for runtime images.
+- **Reproducible deploys** — a digest reference is immutable, so what you tested is exactly what runs.
+
+{{% notice tip %}}
+Prefer the cluster to publish images for you?
+Set `packageRegistry.enabled` (see [OCI image packages]({{% ref "function/oci-packages.md" %}}#automatic-oci-delivery-for-built-packages)) and every on-cluster build publishes a digest-pinned image automatically — your pipeline keeps running `fission spec apply` and gets registry-native delivery without building images itself.
+{{% /notice %}}
+
+## Promote across environments by digest
+
+Because an OCI package is pinned to a digest, promotion is just moving that digest between environments — no rebuild, so staging and production run byte-for-byte what you tested.
+Build and verify once in a lower environment, then apply the **same digest** to the next:
+
+```bash
+fission package update --name hello --oci "ghcr.io/myorg/hello-code@sha256:<digest>"   # in staging
+fission package update --name hello --oci "ghcr.io/myorg/hello-code@sha256:<digest>"   # then prod
+```
+
+In a GitOps setup, this is a pull request that bumps the `deployment.oci.digest` in the next environment's spec directory, applied by that environment's pipeline.
+
+## Continuous deployment
+
+For environments where you want the cluster to track a spec directory continuously rather than on each pipeline run, `fission spec apply --watch` re-applies on local changes.
+In CI/CD, prefer the explicit per-push `fission spec apply --wait` shown above so each deploy is gated on a green build.
+
+## Related
+
+- [YAML Specs]({{% ref "spec/_index.md" %}}) — the declarative spec workflow `fission spec apply` reconciles.
+- [OCI image packages]({{% ref "function/oci-packages.md" %}}) — build code images, pin digests, and configure a package registry.
+- [Package source code]({{% ref "function/package.en.md" %}}) — source vs deployment archives.
+- [Installing Fission]({{% ref "/docs/installation/_index.en.md" %}}) — set up the cluster your pipeline targets.


### PR DESCRIPTION
Highlights the CI/CD way to use Fission and how the new OCI package delivery (1.26) changes CI/CD workflows.

## New page — `docs/usage/cicd.md` ("CI/CD and GitOps")
Sits right after **YAML Specs** in the Usage nav (weight 35) and ties the two together:

- **Foundation:** `fission spec apply` as the idempotent CI/CD control plane (version-controlled specs, safe on every push).
- **GitHub Actions pipeline:** a modern YAML workflow that installs the CLI, configures cluster access from a `KUBECONFIG` secret, and applies specs.
- **Registry-native OCI delivery (the highlight):** build + push a `FROM scratch` code image in CI, deploy **pinned to the pushed digest** (`docker/build-push-action` → `steps.push.outputs.digest`), and the supply-chain wins (no upload/build round trip, cosign/scan, reproducible deploys). Notes the cluster-side auto-publish path (`packageRegistry.enabled`).
- **Promote across environments by digest** — the GitOps story: same digest dev→staging→prod, no rebuild.
- Compact pipeline diagram (color kit, well within the width rule).

## Supporting
- Usage guide map links the new page.
- The **2019 GitHub Action blog** gets a non-destructive 2026 deprecation note (its `.github/main.workflow` syntax is long gone) pointing at the new guide and the OCI packages page.

Verified with `./build.sh` (pinned Hugo 0.157.0): clean build, no path/ref warnings; new page and diagram render; the OCI anchor and the (historically odd) 2019 blog URL both resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)