### PR TITLE
Docs cleanup: env --version with --poolsize, Scoop install, Prometheus release name

### DIFF
--- a/content/en/docs/installation/_index.en.md
+++ b/content/en/docs/installation/_index.en.md
@@ -236,8 +236,13 @@ nix-env -iA nixos.fission
 
 {{< /tab >}}
 {{< tab "Windows" >}}
-For Windows, you can use the linux binary on WSL. Or you can download
-this windows executable: [fission.exe](https://github.com/fission/fission/releases/download/{{% release-version %}}/fission-{{% release-version %}}-windows-amd64.exe)
+On Windows you can install the CLI with [Scoop](https://scoop.sh/):
+
+```powershell
+scoop install fission-cli
+```
+
+Alternatively, you can use the Linux binary on WSL, or download this windows executable: [fission.exe](https://github.com/fission/fission/releases/download/{{% release-version %}}/fission-{{% release-version %}}-windows-amd64.exe)
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/content/en/docs/usage/function/environments.en.md
+++ b/content/en/docs/usage/function/environments.en.md
@@ -22,7 +22,7 @@ $ fission env create --name node \
                      --image ghcr.io/fission/node-env \
                      --mincpu 40 --maxcpu 80 \
                      --minmemory 64 --maxmemory 128 \
-                     --poolsize 4
+                     --version 3 --poolsize 4
 ```
 
 In case of the pool based executor, the resources specified for environment are used for function pod as well.

--- a/content/en/docs/usage/function/functions.en.md
+++ b/content/en/docs/usage/function/functions.en.md
@@ -213,7 +213,7 @@ $ fission env create --name python --image ghcr.io/fission/python-env \
                      --builder ghcr.io/fission/python-builder \
                      --mincpu 40 --maxcpu 80 \
                      --minmemory 64 --maxmemory 128 \
-                     --poolsize 2
+                     --version 3 --poolsize 2
 ```
 
 Now let's zip the directory containing the source files and create a function with source package:

--- a/content/en/docs/usage/function/package.en.md
+++ b/content/en/docs/usage/function/package.en.md
@@ -19,7 +19,7 @@ $ fission env create --name pythonsrc --image ghcr.io/fission/python-env \
                      --builder ghcr.io/fission/python-builder \
                      --mincpu 40 --maxcpu 80 \
                      --minmemory 64 --maxmemory 128 \
-                     --poolsize 2
+                     --version 3 --poolsize 2
 
 environment 'pythonsrc' created
 ```
@@ -134,7 +134,7 @@ $ fission env create --name pythondeploy --image ghcr.io/fission/python-env \
                      --builder ghcr.io/fission/python-builder \
                      --mincpu 40 --maxcpu 80 \
                      --minmemory 64 --maxmemory 128 \
-                     --poolsize 2
+                     --version 3 --poolsize 2
 
 environment 'pythondeploy' created
 ```

--- a/content/en/docs/usage/observability/prometheus.md
+++ b/content/en/docs/usage/observability/prometheus.md
@@ -48,7 +48,7 @@ export METRICS_NAMESPACE=monitoring
 kubectl create namespace $METRICS_NAMESPACE
 ```
 
-Install Prometheus and Grafana with the release name `fission-metrics`.
+Install Prometheus and Grafana with the release name `prometheus`.
 
 ```bash
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
Small, verified documentation fixes batched together.

## Changes

- **`fission env create` examples** — add `--version 3` wherever `--poolsize` is used.
Poolsize is silently ignored unless `--version 3` is set (see `usage/function/executor.en.md`).
Updated `package.en.md` (source + deployment package), `functions.en.md`, and `environments.en.md`.
Closes #217.

- **Windows install via Scoop** — document `scoop install fission-cli` as the recommended Windows option, keeping the WSL / `.exe` fallback.
Closes #221.

- **Prometheus release name** — the prose said release name `fission-metrics` but the helm command uses `prometheus`; align the prose with the command.
Closes #233.

## Verification

`./build.sh` equivalent (`hugo --minify --gc`, Hugo 0.157.0 extended) builds cleanly — 541 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)