### PR TITLE
docs: local development (run-local) and function debugging guides

### DIFF
--- a/content/en/docs/usage/function/debugging.md
+++ b/content/en/docs/usage/function/debugging.md
@@ -1,0 +1,123 @@
+---
+title: "Debugging and diagnosing functions"
+draft: false
+weight: 9
+description: >
+  Diagnose a failing function with fission function describe, read structured failure attribution from fission function test, and trace a single invocation by its request id.
+---
+
+When a function misbehaves, the question is usually *where* it broke — the function code, the build, the executor, or a timeout — and *which* call it was.
+Fission answers both: `fission function describe` shows a function's health in one view, `fission function test` attributes a failure to a component and hands you a request id, and `fission function logs --request-id` pulls that one invocation's logs.
+
+#### See a function's health at a glance
+
+`fission function describe` consolidates what you would otherwise gather from `function getmeta`, `function pods`, and `package info` into a single view:
+
+```bash
+$ fission function describe --name hello
+Name:         hello
+Namespace:    default
+Environment:  nodejs
+Executor:     poolmgr
+Package:      hello-pkg
+Invocable:    Yes (1 of 2 warm pod(s) serving)
+Created:      5m
+
+CONDITIONS:
+  TYPE   STATUS  REASON       MESSAGE
+  Ready  True    PodsReady    ...
+
+PACKAGE:
+  Name:          hello-pkg
+  Build Status:  succeeded
+
+PODS:
+  NAME              READY  STATUS   AGE
+  poolmgr-...-abcd  2/2    Running  5m
+```
+
+The **`Invocable`** line answers "can I call this right now?":
+
+* `Yes (N of M warm pod(s) serving)` — warm pods are published and serving traffic.
+* `Yes (N warm pod(s))` — warm, ready pods exist.
+* `Yes (cold start on first call)` — Ready, but the first call pays a cold start.
+* `No - function not Ready (see CONDITIONS)` — not invocable; the `CONDITIONS` table says why.
+
+Each section is sourced independently, so an unavailable source degrades to `<none>` rather than failing the whole view.
+On a **failed build**, the `PACKAGE` section additionally prints the build log inline — the one place you most need it:
+
+```bash
+$ fission function describe --name broken
+...
+PACKAGE:
+  Name:          broken-pkg
+  Build Status:  failed
+  Build Logs:
+  npm ERR! ... cannot find module 'left-pad'
+```
+
+#### Read the failure attribution
+
+`fission function test` invokes a function and, on failure, tells you which component failed and why instead of just printing a status code.
+Every run echoes the invocation's request id; a failure renders the structured attribution:
+
+```bash
+$ fission function test --name broken
+Request ID: 6f1c2a9e-1c2b-4f0a-9d2e-7b3c2a1d4e5f
+✗ function "broken" failed in executor (specialization_failed) — status 500, request 6f1c2a9e-...
+```
+
+Now you know it failed during **specialization** in the **executor** (not in your code, not a timeout), and you have the request id to find its logs.
+Against an older cluster that does not send structured errors, `test` falls back to printing the raw response body.
+
+#### The failure-attribution contract
+
+Every response — success or failure — carries the request id, and failures add the component, so callers and tooling can attribute a failure without reading server logs:
+
+| Header | Meaning |
+| --- | --- |
+| `X-Fission-Request-ID` | Stable id for the invocation; honored if you send one, otherwise minted by the router. |
+| `X-Fission-Component` | On a failure, the component that failed. |
+
+Failures also return a structured JSON body:
+
+```json
+{
+  "component": "executor",
+  "reason": "specialization_failed",
+  "requestId": "6f1c2a9e-1c2b-4f0a-9d2e-7b3c2a1d4e5f",
+  "traceId": "4bf92f3577b34da6a3ce929d0e0e4736"
+}
+```
+
+The **component** is one of `router`, `executor`, `fetcher`, `function`, or `timeout`.
+The **reason** is a stable value you can match on:
+
+| Reason | Typically means |
+| --- | --- |
+| `function_error` | Your code returned an error or a 5xx. |
+| `function_timeout` | The function exceeded its time budget. |
+| `specialization_failed` | The code failed to load into the environment (bad entry point, import error). |
+| `connection_refused` / `dial_error` | The function pod was not reachable. |
+| `capacity_exceeded` / `executor_unavailable` | The executor could not provide a pod in time. |
+| `client_disconnect` | The caller went away before the response finished. |
+| `stream_idle` / `stream_max_duration` | A [streaming]({{% ref "streaming.md" %}}) response hit its idle or max-duration limit. |
+
+The body never includes raw internal error text by default.
+To get verbose detail for a single call, send `X-Fission-Debug: true`; the router then fills in a `message` field, and only when it runs in debug mode.
+
+{{% notice info %}}
+**Operators:** structured error bodies are on by default and can be turned off with `ROUTER_STRUCTURED_ERRORS=false` on the router, which restores the legacy plain-text error body.
+Status codes are unchanged either way.
+{{% /notice %}}
+
+#### Trace one invocation through the logs
+
+With the request id from `test` (or from a caller's `X-Fission-Request-ID` response header), pull just that invocation's logs — when logs are aggregated with Loki:
+
+```bash
+$ fission function logs --name hello --dbtype loki --request-id 6f1c2a9e-1c2b-4f0a-9d2e-7b3c2a1d4e5f
+```
+
+`--request-id`, `--trace-id`, and `--level` are applied by the `loki` log database and are ignored by the default `kubernetes` driver.
+See [Logs with Loki]({{% ref "/docs/usage/observability/loki.md" %}}) for setup and the full query workflow, and [Local development with run-local]({{% ref "run-local.md" %}}) to reproduce and fix the failure locally without a redeploy.

--- a/content/en/docs/usage/function/run-local.md
+++ b/content/en/docs/usage/function/run-local.md
@@ -1,0 +1,198 @@
+---
+title: "Local development with run-local"
+draft: false
+weight: 8
+description: >
+  Run a function locally in Docker against its real environment image — no cluster round-trip — with hot reload, a builder pass for compiled languages, and secret/configmap mounts.
+---
+
+`fission function run-local` runs a single function on your laptop in Docker, against the **same environment runtime image** the cluster uses, so you can iterate without a build-and-deploy round-trip.
+A normal edit → deploy → test cycle goes through a package build and a specialization on the cluster and takes tens of seconds to a couple of minutes; `run-local` collapses that to a local pull-once, then sub-second re-runs on each edit.
+
+It reproduces the cluster's behavior faithfully — the runtime image, the specialize contract, and the invocation headers all match — so a function that works under `run-local` works the same way once deployed.
+
+{{% notice info %}}
+`run-local` is an **alpha** command; its flags and output may change.
+It needs a running Docker engine and is meant for the local inner loop, not for production traffic.
+{{% /notice %}}
+
+```mermaid
+flowchart LR
+  edit["Edit code"]:::user --> run["fission function<br/>run-local --watch"]:::fission
+  run -->|"pull once + specialize"| ctr["Local env<br/>container"]:::pod
+  ctr -->|"invoke"| resp["Response"]:::store
+  resp -->|"save a file"| edit
+  classDef user fill:#ffffff,stroke:#94a3b8,color:#1f2a43
+  classDef fission fill:#e8f0fe,stroke:#2d70de,color:#1f2a43
+  classDef pod fill:#e6f7f1,stroke:#11a37f,color:#1f2a43,stroke-dasharray:5 3
+  classDef store fill:#fff7e0,stroke:#dba514,color:#1f2a43
+```
+
+#### Prerequisites
+
+* A running **Docker engine** (Docker Desktop, Colima, or any `DOCKER_HOST` the Docker client can reach).
+* Either an environment **image reference** (`--image`, for fully cluster-less use) or a reachable Fission cluster with an `Environment` to resolve from (`--env`).
+
+#### Quick start (no cluster needed)
+
+Point `run-local` at an environment runtime image and a source file:
+
+```bash
+$ cat hello.js
+module.exports = async function (context) {
+  return { status: 200, body: "Hello, world!\n" };
+}
+
+$ fission function run-local --image ghcr.io/fission/node-env --code hello.js
+Pulling ghcr.io/fission/node-env ...
+  pulled 10 layers
+Starting ghcr.io/fission/node-env on 127.0.0.1:63048 ...
+Specializing function ...
+Hello, world!
+```
+
+`run-local` pulls the image (showing layer progress), starts the container, replays the specialize contract over your code, invokes the function once, prints the response, and tears the container down.
+Status lines are color-coded on a terminal — cyan for progress, green for milestones, red for failures, dim for container logs — and plain when the output is piped or `NO_COLOR` is set.
+
+The function is published on `127.0.0.1` at an auto-selected port (shown in the output).
+`--port` sets the port the application **inside** the container listens on (default `8888`, the Fission environment contract port); change it only for a `container` function whose image listens elsewhere.
+
+#### Running against a cluster environment
+
+If you have a cluster, resolve the runtime (and builder) image from an existing `Environment` instead of naming it by hand:
+
+```bash
+$ fission function run-local --env nodejs --code hello.js
+```
+
+`--env` reads the `Environment` CRD for its runtime image; pass `--namespace` to resolve an environment outside `default`.
+Use `--image` instead when you want to stay fully offline or pin a specific image tag.
+
+#### Invoking the function
+
+`run-local` reuses the same invocation flags as [`fission function test`]({{% ref "functions.en.md" %}}), so the request is built exactly as the cluster builds it:
+
+```bash
+$ fission function run-local --image ghcr.io/fission/python-env --code hello.py \
+    --method POST --body '{"name":"ada"}' --header 'Content-Type: application/json'
+```
+
+* `--method` — HTTP method (default `GET`).
+* `--header` / `-H` — request header, repeatable.
+* `--body` / `-b` — request body.
+* `--subpath` — path component for functions that route internally.
+
+#### Hot reload with `--watch`
+
+Add `--watch` (`-w`) to keep the function serving and reload it whenever the source changes — the local equivalent of a dev server:
+
+```bash
+$ fission function run-local --image ghcr.io/fission/node-env --code hello.js --watch
+Starting ghcr.io/fission/node-env on 127.0.0.1:63048 ...
+Specializing function ...
+Serving local at http://127.0.0.1:63048 — watching hello.js for changes (Ctrl-C to stop)
+```
+
+Edit and save `hello.js`, and `run-local` reloads it; `curl http://127.0.0.1:63048` then returns the new response.
+
+The watch scope follows the source:
+
+* A single `--code` file watches that one file.
+* A directory source — `--deploy <dir>`, or a builder project (Go, Java, …) — watches the **whole tree**, so editing any file inside it triggers a reload.
+  Version-control and dependency/build directories (`.git`, `node_modules`, `vendor`, `target`, `.next`, `__pycache__`) and editor swap files are ignored.
+
+A reload **restarts** the container rather than re-specializing in place, because published environment runtimes reject a second specialization on an already-specialized process.
+The restart reuses the same local port, so your `curl` loop keeps working.
+
+{{% notice info %}}
+`--watch` applies to environment executors (`poolmgr`, `newdeploy`) only.
+A `container` function carries its own prebuilt image, so there is nothing to re-specialize.
+{{% /notice %}}
+
+#### Compiled languages with `--build`
+
+Compiled environments (Go, Java, Rust, …) need a build step before the runtime can load the code.
+`--build` runs the environment's **builder image** first — exactly as the cluster's build pipeline does — and feeds the artifact to the runtime:
+
+```bash
+$ fission function run-local --build \
+    --image ghcr.io/fission/go-env-1.26 \
+    --builder-image ghcr.io/fission/go-builder-1.26 \
+    --deploy ./my-go-fn --entrypoint Handler --watch
+Building with ghcr.io/fission/go-builder-1.26 ...
+Pulling ghcr.io/fission/go-env-1.26 ...
+Starting ghcr.io/fission/go-env-1.26 on 127.0.0.1:63092 ...
+Specializing function ...
+Serving local at http://127.0.0.1:63092 — watching ./my-go-fn for changes (Ctrl-C to stop)
+```
+
+* `--build` — compile with the builder image before running.
+* `--builder-image` — builder image to use when running cluster-less; with `--env` it defaults to the environment's builder image.
+* `--buildcmd` — the build command the builder runs (defaults to the environment's build command).
+
+Under `--watch`, editing any file in the source directory re-runs the builder, restarts the runtime, and re-specializes — so a compiled function reloads on save just like an interpreted one.
+
+#### Multi-file applications with `--deploy`
+
+For an app that is more than one file — a multi-module project, or a pre-built bundle such as a Next.js app with its `node_modules` — pass a **directory** with `--deploy`:
+
+```bash
+$ fission function run-local --image ghcr.io/fission/node-env --deploy ./app --entrypoint server
+```
+
+The directory is bind-mounted directly into the container (large dependency trees are not copied), and a `.zip` source is extracted automatically before mounting.
+
+#### Executor types
+
+`--executortype` selects how the function runs, matching the cluster's executor types:
+
+| `--executortype` | What runs locally | Code source |
+| --- | --- | --- |
+| `poolmgr` (default) | The environment runtime image; your code is loaded via the specialize contract. | `--code` or `--deploy` |
+| `newdeploy` | Same as `poolmgr` for local purposes — the environment image plus specialize. | `--code` or `--deploy` |
+| `container` | Your **own** server image, run directly — no environment image, no specialize. | `--image` (the image itself) |
+
+For a [container function]({{% ref "container-functions.md" %}}), point `--image` at your application image and `run-local` starts it and invokes it directly:
+
+```bash
+$ fission function run-local --executortype container --image myorg/my-api:latest --port 8080
+```
+
+#### Injecting configuration
+
+Functions usually need configuration and secrets.
+`run-local` bridges the common sources:
+
+* `-e KEY=VALUE` — set an environment variable in the container (repeatable).
+* `--env-from <file>` — read environment variables from a file (one `KEY=VALUE` per line); `-e` overrides individual keys.
+* `--secret <name>` / `--configmap <name>` — materialize a cluster `Secret`/`ConfigMap` and mount it the way the cluster does, under `/secrets/<namespace>/<name>` and `/configs/<namespace>/<name>` (see [Accessing Secrets and ConfigMaps]({{% ref "access-secret-cfgmap-in-function.en.md" %}})).
+  These require a reachable cluster to read the objects from.
+
+#### Attaching a debugger
+
+`--debug-port <N>` publishes an extra container port so a debugger (Delve for Go, debugpy for Python, …) can attach to the running function.
+Combine it with `--keep` to leave the container and mounts running after the invocation instead of tearing them down, so you can attach, inspect, and re-invoke at will:
+
+```bash
+$ fission function run-local --image ghcr.io/fission/python-env --code hello.py \
+    --debug-port 5678 --keep
+```
+
+#### Fidelity and limitations
+
+`run-local` is high-fidelity but not a cluster.
+What matches and what does not:
+
+| Matches the cluster | Differs from the cluster |
+| --- | --- |
+| Environment runtime image | In-cluster DNS / service discovery |
+| Specialize (load) contract, v1 and v2 | ServiceAccount, RBAC, and pod identity |
+| Invocation path and `X-Fission-*` headers | NetworkPolicy and admission control |
+| Builder image and build contract (`--build`) | Triggers (HTTP routes, timers, message queues) |
+
+For anything that depends on the cluster — calling another in-cluster service, real RBAC, or trigger wiring — deploy to a development cluster and use [`fission function test`]({{% ref "functions.en.md" %}}) and [Debugging and diagnosing functions]({{% ref "debugging.md" %}}).
+
+#### Flag reference
+
+The full, always-current flag list is in `fission function run-local --help` and the [CLI reference]({{% ref "/docs/reference/fission-cli/_index.md" %}}).
+The flags above cover the common workflows; `--env-version` selects the environment API version (default `2`) when running cluster-less with `--image`.

--- a/content/en/docs/usage/observability/loki.md
+++ b/content/en/docs/usage/observability/loki.md
@@ -213,6 +213,26 @@ Loki is great for performing metrics over the logs, for example:
 
 - Count of all logs in Fission Router with "error" over span of 5 mins `count_over_time({svc="router"} |= "error" [5m])`.
 
+### Querying logs from the Fission CLI
+
+You do not have to open Grafana to read function logs.
+With Loki configured, `fission function logs --dbtype loki` queries it directly, and a few filters make it easy to follow a single function or a single invocation:
+
+```bash
+# Stream a function's logs as they arrive
+$ fission function logs --name hello --dbtype loki --follow
+
+# Just the logs for one invocation, by its X-Fission-Request-ID
+$ fission function logs --name hello --dbtype loki --request-id 6f1c2a9e-1c2b-4f0a-9d2e-7b3c2a1d4e5f
+
+# Filter by trace id or level
+$ fission function logs --name hello --dbtype loki --trace-id 4bf92f3577b34da6a3ce929d0e0e4736
+$ fission function logs --name hello --dbtype loki --level error
+```
+
+`--request-id`, `--trace-id`, and `--level` are applied by the `loki` driver only; the default `kubernetes` driver ignores them.
+The request id comes from the `X-Fission-Request-ID` response header or from `fission function test` — see [Debugging and diagnosing functions]({{% ref "/docs/usage/function/debugging.md" %}}) for how to get it and attribute a failure to a component.
+
 ## Fission Logs Dashboard
 
 Grafana provides a great way to build visual dashboards by aggregating queries.


### PR DESCRIPTION
## What

Documents shipped-but-undocumented developer features so they're discoverable for adoption.

| Page | Documents |
| --- | --- |
| **NEW** `usage/function/run-local.md` | `fission function run-local` (RFC-0018) — the local Docker inner loop: cluster-less (`--image`) and `--env` use, invocation flags, `--watch` hot reload (single-file + compiled-project tree-watch), `--build` for compiled languages, `--deploy` multi-file apps, the three executor types, config injection (`-e`/`--env-from`/`--secret`/`--configmap`), `--debug-port`/`--keep`, and a fidelity-vs-cluster matrix. |
| **NEW** `usage/function/debugging.md` | `fission function describe` (one-view health + build logs), the self-diagnosing `fission function test` output, the `X-Fission-Request-ID` / `X-Fission-Component` failure-attribution contract and reason taxonomy, and tracing one invocation via `fission function logs --request-id` (RFC-0015/0017). |
| **ENHANCE** `usage/observability/loki.md` | A "Querying logs from the Fission CLI" section: `--dbtype loki` with `--follow`/`--request-id`/`--trace-id`/`--level` (RFC-0016). |

These three are in one PR because they cross-link each other (run-local ↔ debugging ↔ loki), and Hugo fails the build on a broken ref.

## Notes

- Every flag/behavior was checked against the real `fission function ... --help`, not RFC text.
- All `{{% ref %}}` cross-links resolve; Hugo's render-pages step passes with no broken refs.
- The CLI reference under `docs/reference/fission-cli/*` is auto-generated and not touched here — the `run-local`/`describe` stubs regenerate from the CLI separately.
- `run-local` is documented as **Alpha**, matching the command's own help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)