### PR TITLE
docs: remove internal skill reference from building-environment page

### DIFF
--- a/content/en/docs/usage/function/building-environment.en.md
+++ b/content/en/docs/usage/function/building-environment.en.md
@@ -274,7 +274,7 @@ Then:
 8. Open a PR against [fission/environments](https://github.com/fission/environments).
    On merge, CI builds and publishes `ghcr.io/fission/mylang-env` (and the builder) at the version in `envconfig.json`.
 
-Finally, surface the new language on this website's [Environments catalog](/environments/) by running `tools/environments.py` to regenerate `static/data/environments.json` — see the **updating-environments-and-examples** workflow and [tools/README.md](https://github.com/fission/fission.io/blob/main/tools/README.md).
+Finally, surface the new language on this website's [Environments catalog](/environments/) by running `tools/environments.py` to regenerate `static/data/environments.json` — see [tools/README.md](https://github.com/fission/fission.io/blob/main/tools/README.md) for the `env_dict` mapping step.
 
 ## Build and test locally
 


### PR DESCRIPTION
## What

The "build a custom environment" page referenced an internal `.claude` skill name (`updating-environments-and-examples`) in published prose — meaningless to a public reader. Replaced it with the existing `tools/README.md` pointer (which documents the `env_dict` mapping step).

One-line content change; verified with `./build.sh` on the `netlify.toml`-pinned Hugo (0.157.0) — 567 pages, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)