### PR TITLE
Upgrade docs lightbox: pinch zoom, +/− controls, fit-with-padding

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -839,68 +839,78 @@ a {
 	cursor: zoom-in;
 }
 
-/* Fullscreen lightbox for diagrams and images. */
+/* Fullscreen lightbox for diagrams and images (script in
+   layouts/partials/hooks/body-end.html): click opens a full-screen
+   panel, wheel/pinch zooms, drag pans, +/− buttons step zoom,
+   ×/Escape/backdrop close, double-click refits. */
 .fission-lightbox {
 	position: fixed;
 	inset: 0;
 	z-index: 2000;
-	background: rgba(18, 19, 20, 0.82);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	overflow: hidden;
-	cursor: grab;
-	touch-action: none;
+	padding: 1rem;
+	background: rgba(18, 19, 20, 0.6);
 }
 
-.fission-lightbox.is-dragging {
+.fission-lightbox__panel {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	border-radius: 12px;
+	background: #ffffff;
+	box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+	touch-action: none;
+	cursor: grab;
+}
+
+.fission-lightbox__panel:active {
 	cursor: grabbing;
 }
 
 .fission-lightbox__stage {
-	background: #ffffff;
-	border-radius: 8px;
-	padding: 1.5rem;
-	box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
-	transition: transform 60ms linear;
+	position: absolute;
+	top: 0;
+	left: 0;
+	transform-origin: 0 0;
+}
+
+.fission-lightbox__stage img,
+.fission-lightbox__stage svg {
+	display: block;
 	max-width: none;
 }
 
-.fission-lightbox__stage img {
-	display: block;
-	max-width: 85vw;
-	max-height: 80vh;
-}
-
-.fission-lightbox__stage svg {
-	display: block;
-}
-
-.fission-lightbox__close {
-	position: fixed;
+.fission-lightbox__controls {
+	position: absolute;
 	top: 1rem;
-	right: 1.25rem;
-	width: 2.75rem;
-	height: 2.75rem;
+	right: 1rem;
+	z-index: 1;
+	display: flex;
+	gap: 0.5rem;
+}
+
+.fission-lightbox__btn {
+	width: 2.5rem;
+	height: 2.5rem;
 	border: none;
 	border-radius: 50%;
-	background: rgba(255, 255, 255, 0.92);
+	background: rgba(31, 42, 67, 0.08);
 	color: #1f2a43;
-	font-size: 1.75rem;
+	font-size: 1.35rem;
 	line-height: 1;
 	cursor: pointer;
 }
 
-.fission-lightbox__close:hover {
-	background: #ffffff;
+.fission-lightbox__btn:hover {
+	background: rgba(31, 42, 67, 0.16);
 }
 
 .fission-lightbox__hint {
-	position: fixed;
+	position: absolute;
 	bottom: 1rem;
 	left: 50%;
 	transform: translateX(-50%);
-	color: rgba(255, 255, 255, 0.85);
+	color: #5a5b75;
 	font-size: 0.85rem;
 	pointer-events: none;
 }

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -37,140 +37,196 @@
 
 {{/*
   Docs lightbox: click a mermaid diagram or content image to open it in a
-  fullscreen overlay with wheel/double-click zoom and drag panning.
-  Dependency-free; ESC, backdrop click, or the close button dismiss it.
+  fullscreen panel. Wheel or pinch zooms around the cursor/midpoint, drag
+  pans, +/− buttons step zoom, ×/Escape/backdrop close, double-click
+  refits. Dependency-free; styles under .fission-lightbox in
+  assets/scss/_variables_project.scss.
 */}}
 <script>
 (function () {
+  var MIN_SCALE = 0.2;
+  var MAX_SCALE = 12;
+  var BTN_STEP = 1.3;
+  var WHEEL_STEP = 1.15;
+  var FIT_PAD = 56; // px of breathing room around the fitted content
+
+  function contentSize(node) {
+    if (node.tagName.toLowerCase() === 'svg') {
+      var vb = node.viewBox && node.viewBox.baseVal;
+      if (vb && vb.width && vb.height) return { w: vb.width, h: vb.height };
+    } else if (node.naturalWidth && node.naturalHeight) {
+      return { w: node.naturalWidth, h: node.naturalHeight };
+    }
+    var r = node.getBoundingClientRect();
+    return { w: r.width || 800, h: r.height || 600 };
+  }
+
   function openLightbox(node) {
+    var size = contentSize(node);
+
     var overlay = document.createElement('div');
     overlay.className = 'fission-lightbox';
     overlay.setAttribute('role', 'dialog');
-    overlay.setAttribute('aria-label', 'Zoomed diagram');
+    overlay.setAttribute('aria-label', 'Zoomed content');
+    overlay.innerHTML =
+      '<div class="fission-lightbox__panel">' +
+      '<div class="fission-lightbox__stage"></div>' +
+      '<div class="fission-lightbox__controls">' +
+      '<button class="fission-lightbox__btn" data-zoom="in" aria-label="Zoom in" title="Zoom in">+</button>' +
+      '<button class="fission-lightbox__btn" data-zoom="out" aria-label="Zoom out" title="Zoom out">&minus;</button>' +
+      '<button class="fission-lightbox__btn" data-zoom="close" aria-label="Close" title="Close">&times;</button>' +
+      '</div>' +
+      '<div class="fission-lightbox__hint">Scroll or pinch to zoom &middot; drag to pan &middot; double-click to reset &middot; Esc to close</div>' +
+      '</div>';
+    var panel = overlay.firstChild;
+    var stage = panel.querySelector('.fission-lightbox__stage');
 
-    var stage = document.createElement('div');
-    stage.className = 'fission-lightbox__stage';
-
-    var srcRect = node.getBoundingClientRect();
-    // Keep the id: mermaid embeds a <style> scoped to the svg id, and CSS id
-    // selectors match every element carrying it, so the clone stays styled.
+    // Clone at natural (viewBox / intrinsic) size; inline max-width styles
+    // would otherwise fight the transform math. Keep the id: mermaid embeds
+    // a <style> scoped to the svg id, so the clone stays styled.
     var content = node.cloneNode(true);
-    if (content.tagName.toLowerCase() === 'svg') {
-      // Give the clone an explicit comfortable width; viewBox keeps the ratio.
-      content.removeAttribute('width');
-      content.removeAttribute('height');
-      content.style.maxWidth = 'none';
-      var target = Math.min(window.innerWidth * 0.85, Math.max(srcRect.width * 2, 640));
-      var ratio = srcRect.width > 0 ? srcRect.height / srcRect.width : 0.6;
-      if (target * ratio > window.innerHeight * 0.8) {
-        target = (window.innerHeight * 0.8) / ratio;
-      }
-      content.style.width = target + 'px';
-      content.style.height = 'auto';
-    }
+    content.removeAttribute('style');
+    content.setAttribute('width', size.w);
+    content.setAttribute('height', size.h);
     stage.appendChild(content);
 
-    var close = document.createElement('button');
-    close.className = 'fission-lightbox__close';
-    close.setAttribute('aria-label', 'Close');
-    close.innerHTML = '&times;';
-
-    var hint = document.createElement('div');
-    hint.className = 'fission-lightbox__hint';
-    hint.textContent = 'Scroll to zoom · drag to pan · Esc to close';
-
-    overlay.appendChild(stage);
-    overlay.appendChild(close);
-    overlay.appendChild(hint);
     document.body.appendChild(overlay);
     document.body.style.overflow = 'hidden';
 
-    var scale = 1, tx = 0, ty = 0;
-    var dragging = false, lastX = 0, lastY = 0, moved = false;
+    var scale = 1;
+    var tx = 0;
+    var ty = 0;
 
     function apply() {
       stage.style.transform = 'translate(' + tx + 'px,' + ty + 'px) scale(' + scale + ')';
     }
 
-    function destroy() {
-      document.body.style.overflow = '';
-      document.removeEventListener('keydown', onKey);
-      overlay.remove();
+    // Fit within the panel with FIT_PAD margins; never upscale small
+    // content past natural size — whitespace beats blur.
+    function fit() {
+      var pw = panel.clientWidth;
+      var ph = panel.clientHeight;
+      scale = Math.min((pw - 2 * FIT_PAD) / size.w, (ph - 2 * FIT_PAD) / size.h, 1);
+      scale = Math.max(scale, MIN_SCALE);
+      tx = (pw - size.w * scale) / 2;
+      ty = (ph - size.h * scale) / 2;
+      apply();
     }
-    function onKey(e) { if (e.key === 'Escape') destroy(); }
-    document.addEventListener('keydown', onKey);
-    close.addEventListener('click', destroy);
-    overlay.addEventListener('click', function (e) {
-      if (e.target === overlay && !moved) destroy();
-      moved = false;
-    });
 
-    overlay.addEventListener('wheel', function (e) {
-      e.preventDefault();
-      var next = Math.min(8, Math.max(0.3, scale * (e.deltaY < 0 ? 1.12 : 0.89)));
+    // Zoom keeping the panel-relative point (px, py) fixed on screen.
+    // Stage has transform-origin 0 0, so: tx' = px − (px − tx)·f.
+    function zoomAt(px, py, factor) {
+      var next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale * factor));
+      factor = next / scale;
+      if (factor === 1) return;
+      tx = px - (px - tx) * factor;
+      ty = py - (py - ty) * factor;
       scale = next;
       apply();
+    }
+
+    function onKey(e) {
+      if (e.key === 'Escape') close();
+    }
+
+    function close() {
+      overlay.remove();
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', onKey);
+    }
+
+    panel.addEventListener('wheel', function (e) {
+      e.preventDefault();
+      var rect = panel.getBoundingClientRect();
+      // ctrlKey wheel is a macOS trackpad pinch — track it continuously.
+      var factor = e.ctrlKey
+        ? Math.exp(-e.deltaY * 0.01)
+        : (e.deltaY < 0 ? WHEEL_STEP : 1 / WHEEL_STEP);
+      zoomAt(e.clientX - rect.left, e.clientY - rect.top, factor);
     }, { passive: false });
 
-    stage.addEventListener('dblclick', function (e) {
+    // One pointer pans, two pinch-zoom around their midpoint.
+    var pointers = new Map();
+    panel.addEventListener('pointerdown', function (e) {
+      if (e.target.closest('.fission-lightbox__controls')) return;
       e.preventDefault();
-      scale = scale < 2 ? scale * 1.8 : 1;
-      if (scale === 1) { tx = 0; ty = 0; }
-      apply();
+      pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      // Best-effort: keeps the drag when the pointer leaves the panel.
+      try { panel.setPointerCapture(e.pointerId); } catch (err) {}
     });
+    panel.addEventListener('pointermove', function (e) {
+      var prev = pointers.get(e.pointerId);
+      if (!prev) return;
+      if (pointers.size === 1) {
+        tx += e.clientX - prev.x;
+        ty += e.clientY - prev.y;
+        apply();
+      } else if (pointers.size === 2) {
+        var rect = panel.getBoundingClientRect();
+        var entries = Array.from(pointers.entries());
+        var other = entries[0][0] === e.pointerId ? entries[1][1] : entries[0][1];
+        var prevMidX = (prev.x + other.x) / 2 - rect.left;
+        var prevMidY = (prev.y + other.y) / 2 - rect.top;
+        var prevDist = Math.hypot(prev.x - other.x, prev.y - other.y);
+        var midX = (e.clientX + other.x) / 2 - rect.left;
+        var midY = (e.clientY + other.y) / 2 - rect.top;
+        var dist = Math.hypot(e.clientX - other.x, e.clientY - other.y);
+        if (prevDist > 0) zoomAt(prevMidX, prevMidY, dist / prevDist);
+        tx += midX - prevMidX;
+        ty += midY - prevMidY;
+        apply();
+      }
+      pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    });
+    function releasePointer(e) {
+      pointers.delete(e.pointerId);
+    }
+    panel.addEventListener('pointerup', releasePointer);
+    panel.addEventListener('pointercancel', releasePointer);
 
-    overlay.addEventListener('pointerdown', function (e) {
-      dragging = true; moved = false;
-      lastX = e.clientX; lastY = e.clientY;
-      overlay.setPointerCapture(e.pointerId);
-      overlay.classList.add('is-dragging');
+    panel.addEventListener('dblclick', function (e) {
+      if (!e.target.closest('.fission-lightbox__controls')) fit();
     });
-    overlay.addEventListener('pointermove', function (e) {
-      if (!dragging) return;
-      var dx = e.clientX - lastX, dy = e.clientY - lastY;
-      if (Math.abs(dx) + Math.abs(dy) > 2) moved = true;
-      tx += dx; ty += dy;
-      lastX = e.clientX; lastY = e.clientY;
-      apply();
+    panel.querySelector('[data-zoom="in"]').addEventListener('click', function () {
+      zoomAt(panel.clientWidth / 2, panel.clientHeight / 2, BTN_STEP);
     });
-    overlay.addEventListener('pointerup', function () {
-      dragging = false;
-      overlay.classList.remove('is-dragging');
+    panel.querySelector('[data-zoom="out"]').addEventListener('click', function () {
+      zoomAt(panel.clientWidth / 2, panel.clientHeight / 2, 1 / BTN_STEP);
     });
+    panel.querySelector('[data-zoom="close"]').addEventListener('click', close);
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) close();
+    });
+    document.addEventListener('keydown', onKey);
+
+    fit();
   }
 
   function wire() {
-    document.querySelectorAll('.td-content .mermaid svg').forEach(function (svg) {
-      var holder = svg.closest('.mermaid');
-      if (holder && !holder.dataset.lightbox) {
-        holder.dataset.lightbox = '1';
-        holder.classList.add('fission-zoomable');
-        holder.addEventListener('click', function () { openLightbox(svg); });
-      }
+    // Mermaid renders asynchronously; bind the container now and look the
+    // svg up at click time, so no MutationObserver is needed.
+    document.querySelectorAll('.td-content .mermaid').forEach(function (holder) {
+      if (holder.dataset.lightbox) return;
+      holder.dataset.lightbox = '1';
+      holder.classList.add('fission-zoomable');
+      holder.setAttribute('title', 'Click to zoom');
+      holder.addEventListener('click', function () {
+        var svg = holder.querySelector('svg');
+        if (svg) openLightbox(svg);
+      });
     });
     document.querySelectorAll('.td-content .post-img img, .td-content > img, .td-content p > img').forEach(function (img) {
-      if (!img.dataset.lightbox) {
-        img.dataset.lightbox = '1';
-        img.classList.add('fission-zoomable');
-        img.addEventListener('click', function () { openLightbox(img); });
-      }
+      if (img.dataset.lightbox) return;
+      img.dataset.lightbox = '1';
+      img.classList.add('fission-zoomable');
+      img.addEventListener('click', function () { openLightbox(img); });
     });
   }
 
-  // Mermaid renders asynchronously after load; observe until diagrams settle.
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', wire);
   } else {
     wire();
-  }
-  var pending = document.querySelectorAll('.td-content .mermaid:not([data-processed])').length;
-  if (pending > 0) {
-    var observer = new MutationObserver(function () {
-      wire();
-      if (!document.querySelector('.td-content .mermaid:not([data-processed])')) observer.disconnect();
-    });
-    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['data-processed'] });
-    setTimeout(function () { observer.disconnect(); }, 15000);
   }
 })();
 </script>


### PR DESCRIPTION
Upgrades the mermaid-diagram and content-image lightbox to a deepwiki-style zoom panel.

## What
- Click a diagram or image to open it in a full-screen white panel.
The content fits with wide margins and never upscales past its natural size.
- Wheel and two-finger pinch zoom around the cursor/midpoint; ctrl+wheel covers macOS trackpad pinch.
- Drag pans; double-click refits.
- `+`/`−`/`×` buttons top right; Escape and backdrop click also close.
- Diagrams bind at page load and the svg is looked up at click time, so the old MutationObserver is gone.

Touched files: `layouts/partials/hooks/body-end.html` (script) and `assets/scss/_variables_project.scss` (`.fission-lightbox` styles).

## Verification
- `./build.sh` passes with Hugo extended 0.157.0 (the Netlify-pinned version).
- Browser-verified locally: mermaid diagram on `docs/usage/multi-namespace-tenancy` (open/fit, + button, wheel zoom, ×/Escape close, body scroll restore) and an image on a blog post (open, Escape close).
- The pinch handler is identical code to a pinch-tested implementation on another site.